### PR TITLE
Use $PGDATA env var to setup wal-e

### DIFF
--- a/db/setup-wale.sh
+++ b/db/setup-wale.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 # wal-e specific
-echo "wal_level = archive" >> /var/lib/postgresql/data/postgresql.conf
-echo "archive_mode = on" >> /var/lib/postgresql/data/postgresql.conf
-echo "archive_command = 'envdir /etc/wal-e.d/env /usr/local/bin/wal-e wal-push %p'" >> /var/lib/postgresql/data/postgresql.conf
-echo "archive_timeout = 60" >> /var/lib/postgresql/data/postgresql.conf
+echo "wal_level = $WAL_LEVEL" >> $PGDATA/postgresql.conf
+echo "archive_mode = $ARCHIVE_MODE" >> $PGDATA/postgresql.conf
+echo "archive_command = 'envdir /etc/wal-e.d/env /usr/local/bin/wal-e wal-push %p'" >> $PGDATA/postgresql.conf
+echo "archive_timeout = 60" >> $PGDATA/postgresql.conf
 
 # no cron in the image, use systemd timer on host instead
 #su - postgres -c "crontab -l | { cat; echo \"0 3 * * * /usr/bin/envdir /etc/wal-e.d/env /usr/local/bin/wal-e backup-push /var/lib/postgresql/data\"; } | crontab -"


### PR DESCRIPTION
$PGDATA is set in upstream postgres dockerfile and should be used in
downstream in case the postgres data directory is changed in the future.

This PR depends on #18 