### PR TITLE
Removed check if /mattermost/config/config.json already exists before…

### DIFF
--- a/app/docker-entry.sh
+++ b/app/docker-entry.sh
@@ -6,18 +6,14 @@ MM_USERNAME=${MM_USERNAME:-mmuser}
 MM_PASSWORD=${MM_PASSWORD:-mmuser_password}
 MM_DBNAME=${MM_DBNAME:-mattermost}
 echo -ne "Configure database connection..."
-if [ ! -f $config ]
-then
-    cp /config.template.json $config
-    sed -Ei "s/DB_HOST/$DB_HOST/" $config
-    sed -Ei "s/DB_PORT/$DB_PORT_5432_TCP_PORT/" $config
-    sed -Ei "s/MM_USERNAME/$MM_USERNAME/" $config
-    sed -Ei "s/MM_PASSWORD/$MM_PASSWORD/" $config
-    sed -Ei "s/MM_DBNAME/$MM_DBNAME/" $config
-    echo OK
-else
-    echo SKIP
-fi
+
+cp /config.template.json $config
+sed -Ei "s/DB_HOST/$DB_HOST/" $config
+sed -Ei "s/DB_PORT/$DB_PORT_5432_TCP_PORT/" $config
+sed -Ei "s/MM_USERNAME/$MM_USERNAME/" $config
+sed -Ei "s/MM_PASSWORD/$MM_PASSWORD/" $config
+sed -Ei "s/MM_DBNAME/$MM_DBNAME/" $config
+echo OK
 
 echo "Wait until database is ready..."
 until nc -z $DB_HOST $DB_PORT_5432_TCP_PORT


### PR DESCRIPTION
… using config.template and environment values to create new config.json.

When Dockerfile install mattermost it will always write /mattermost/config/config.json file, therefore using environment values to create new config.json never happens if there is this file check.

Also if one whishes to restart docker with new database value there is good reason to always create new config file from environment values.