### PR TITLE
Fixed incorrect SSL certificate path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ See [README.aws.md](./README.aws.md) if you want to install it on AWS Elastic Be
       - MATTERMOST_ENABLE_SSL=true
     ```
 
-2. Put your SSL certificate as `./volumes/cert/cert.pem` and the private key that has
-   no password as `./volumes/cert/key-no-password.pem`. If you don't have
+2. Put your SSL certificate as `./volumes/web/cert/cert.pem` and the private key that has
+   no password as `./volumes/web/cert/key-no-password.pem`. If you don't have
    them you may generate a self-signed SSL certificate.
 
 3. Build and run mattermost


### PR DESCRIPTION
The path for the SSL certificates appears to be incorrect, from what I can tell. By using the location `./volumes/cert/` the web container fails to start, but by using `./volumes/web/cert` everything seems to work as intended.