### PR TITLE
Fixed cert path

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ See [README.aws.md](./README.aws.md) if you want to install it on AWS Elastic Be
       - MATTERMOST_ENABLE_SSL=true
     ```
 
-2. Put your SSL certificate as `./volumes/cert/cert.pem` and the private key that has
-   no password as `./volumes/cert/key-no-password.pem`. If you don't have
+2. Put your SSL certificate as `./volumes/web/cert/cert.pem` and the private key that has
+   no password as `./volumes/web/cert/key-no-password.pem`. If you don't have
    them you may generate a self-signed SSL certificate.
 
 3. Build and run mattermost


### PR DESCRIPTION
In the docker-compose.yml the certificate folder is defined to be in the web directory. So I changed the README.md

```
  volumes:
      # This directory must have cert files
    - ./volumes/web/cert:/cert:ro
```