### PR TITLE
Fixing web proxy dealing with protocols

### DIFF
--- a/web/mattermost
+++ b/web/mattermost
@@ -1,3 +1,8 @@
+map $http_x_forwarded_proto $proxy_x_forwarded_proto {
+  default $http_x_forwarded_proto;
+  ''      $scheme;
+}
+
 server {
     listen 80;
 
@@ -10,7 +15,7 @@ server {
         proxy_set_header Host $http_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto $proxy_x_forwarded_proto;
         proxy_set_header X-Frame-Options SAMEORIGIN;
         proxy_pass http://app:APP_PORT;
     }

--- a/web/mattermost-ssl
+++ b/web/mattermost-ssl
@@ -4,6 +4,11 @@
 #     return         301 https://$server_name$request_uri;
 # }
 
+map $http_x_forwarded_proto $proxy_x_forwarded_proto {
+  default $http_x_forwarded_proto;
+  ''      $scheme;
+}
+
 server {
     listen 443;
 
@@ -25,7 +30,7 @@ server {
         proxy_set_header Host $http_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto $proxy_x_forwarded_proto;
         proxy_set_header X-Frame-Options SAMEORIGIN;
         proxy_pass http://app:APP_PORT;
     }


### PR DESCRIPTION
See #57 and https://github.com/mattermost/platform/issues/3944

Added workarounds to both nginx configs (ssl and no ssl) to grab the correct protocol and pass it in the `X-Forwared-Proto` header.

If this web proxy receives a connection which already has `X-Forwared-Proto` set it will use this, otherwise it will sue default `$scheme` variable.
