### PR TITLE
Allow config location to be customized from CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,34 @@ docker exec mattermost-db su - postgres sh -c "/usr/bin/envdir /etc/wal-e.d/env 
 ```
 Those tasks can be executed through a cron job or systemd timer.
 
+## Customization
+
+Customization can be done through environment variables.
+
+### Mattermost App Image
+
+* MM_USERNAME: database username, must be the same as one in DB image
+* MM_PASSWORD: database password, must be the same as one in DB image
+* MM_DBNAME: database name, must be the same as one in DB image
+* DB_HOST: database host address
+* DB_PORT_5432_TCP_PORT: database port
+* MM_CONFIG: configuration file location. It can be used when config is mounted in a different location.
+
+### Mattermost DB Image
+
+* MM_USERNAME: database username, must be the same as on in App image
+* MM_PASSWORD: database password, must be the same as on in App image
+* MM_DBNAME: database name, must be the same as on in App image
+* AWS_ACCESS_KEY_ID: aws access key, used for db backup
+* AWS_SECRET_ACCESS_KEY: aws secret, used for db backup
+* WALE_S3_PREFIX: aws s3 bucket name, used for db backup
+* AWS_REGION: aws region, used for db backup
+
+### Mattermost Web Image
+
+* MATTERMOST_ENABLE_SSL: whether to enable SSL
+* PLATFORM_PORT_80_TCP_PORT: port that Mattermost image is listening on
+
 ## Upgrading to Team Edition 3.0.x from 2.x
 
 You need to migrate your database before upgrading mattermost to 3.0.x from

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,9 +1,13 @@
 FROM ubuntu:14.04
 
+ENV PATH="/mattermost/bin:${PATH}"
+
 RUN apt-get update && apt-get -y install curl netcat
 RUN mkdir -p /mattermost/data
 
-RUN curl https://releases.mattermost.com/3.6.2/mattermost-team-3.6.2-linux-amd64.tar.gz | tar -xvz
+ENV MM_VERSION=3.6.2
+
+RUN curl https://releases.mattermost.com/$MM_VERSION/mattermost-team-$MM_VERSION-linux-amd64.tar.gz | tar -xvz
 
 RUN rm /mattermost/config/config.json
 COPY config.template.json /
@@ -13,3 +17,8 @@ RUN chmod +x /docker-entry.sh
 ENTRYPOINT ["/docker-entry.sh"]
 
 EXPOSE 80
+
+VOLUME /mattermost/data
+
+WORKDIR /mattermost/bin
+CMD ["platform"]

--- a/app/docker-entry.sh
+++ b/app/docker-entry.sh
@@ -1,33 +1,51 @@
 #!/bin/bash
-config=/mattermost/config/config.json
+
 DB_HOST=${DB_HOST:-db}
 DB_PORT_5432_TCP_PORT=${DB_PORT_5432_TCP_PORT:-5432}
 MM_USERNAME=${MM_USERNAME:-mmuser}
 MM_PASSWORD=${MM_PASSWORD:-mmuser_password}
 MM_DBNAME=${MM_DBNAME:-mattermost}
-echo -ne "Configure database connection..."
-if [ ! -f $config ]
-then
-    cp /config.template.json $config
-    sed -Ei "s/DB_HOST/$DB_HOST/" $config
-    sed -Ei "s/DB_PORT/$DB_PORT_5432_TCP_PORT/" $config
-    sed -Ei "s/MM_USERNAME/$MM_USERNAME/" $config
-    sed -Ei "s/MM_PASSWORD/$MM_PASSWORD/" $config
-    sed -Ei "s/MM_DBNAME/$MM_DBNAME/" $config
-    echo OK
-else
-    echo SKIP
+MM_CONFIG=/mattermost/config/config.json
+
+if [ "${1:0:1}" = '-' ]; then
+    set -- platform "$@"
 fi
 
-echo "Wait until database $DB_HOST:$DB_PORT_5432_TCP_PORT is ready..."
-until nc -z $DB_HOST $DB_PORT_5432_TCP_PORT
-do
+if [ "$1" = 'platform' ]; then
+    for ARG in $@;
+    do
+        case "$ARG" in
+            -config=*)
+                MM_CONFIG=${ARG#*=};;
+        esac
+    done
+
+    echo "Using config file" $MM_CONFIG
+
+    echo -ne "Configure database connection..."
+    if [ ! -f $MM_CONFIG ]
+    then
+        cp /config.template.json $MM_CONFIG
+        sed -Ei "s/DB_HOST/$DB_HOST/" $MM_CONFIG
+        sed -Ei "s/DB_PORT/$DB_PORT_5432_TCP_PORT/" $MM_CONFIG
+        sed -Ei "s/MM_USERNAME/$MM_USERNAME/" $MM_CONFIG
+        sed -Ei "s/MM_PASSWORD/$MM_PASSWORD/" $MM_CONFIG
+        sed -Ei "s/MM_DBNAME/$MM_DBNAME/" $MM_CONFIG
+        echo OK
+    else
+        echo SKIP
+    fi
+
+    echo "Wait until database $DB_HOST:$DB_PORT_5432_TCP_PORT is ready..."
+    until nc -z $DB_HOST $DB_PORT_5432_TCP_PORT
+    do
+        sleep 1
+    done
+
+    # Wait to avoid "panic: Failed to open sql connection pq: the database system is starting up"
     sleep 1
-done
 
-# Wait to avoid "panic: Failed to open sql connection pq: the database system is starting up"
-sleep 1
+    echo "Starting platform"
+fi
 
-echo "Starting platform"
-cd /mattermost/bin
-./platform $*
+exec "$@"

--- a/docker-compose-v1.yml
+++ b/docker-compose-v1.yml
@@ -13,6 +13,8 @@ db:
   #  - AWS_SECRET_ACCESS_KEY=XXXX
   #  - WALE_S3_PREFIX=s3://BUCKET_NAME/PATH
   #  - AWS_REGION=us-east-1
+  #  in case your config is not in default location
+  #  - MM_CONFIG=/mattermost/config/config.jso
 app:
   build: app
   links:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,8 @@ services:
     #  - AWS_SECRET_ACCESS_KEY=XXXX
     #  - WALE_S3_PREFIX=s3://BUCKET_NAME/PATH
     #  - AWS_REGION=us-east-1
+    #  in case your config is not in default location
+    #  - MM_CONFIG=/mattermost/config/config.jso
 
   app:
     build: app


### PR DESCRIPTION
Config file should be stored in a persistent storage as it is stores the
app status and configuration. It should be independent from container
life cycle and mounted into app container. This commit allows config
location to be changed through CLI. So that when the persistent storage
is mounted, the location can be pointed to the mounted config file.

Also some updates for best practices:
* extracted version numbers in Dockerfile into a environment variable
* Added mattermost/bin to PATH environment variable