### PR TITLE
Bump docker-compose.yml version to 2.1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,39 +1,41 @@
-db:
-  build: db
-  restart: always
-  volumes:
-    - ./volumes/db/var/lib/postgresql/data:/var/lib/postgresql/data
-    - /etc/localtime:/etc/localtime:ro
-  # uncomment the following to enable backup
-  environment:
-    - MM_USERNAME=mmuser
-    - MM_PASSWORD=mmuser_password
-    - MM_DBNAME=mattermost
-  #  - AWS_ACCESS_KEY_ID=XXXX
-  #  - AWS_SECRET_ACCESS_KEY=XXXX
-  #  - WALE_S3_PREFIX=s3://BUCKET_NAME/PATH
-  #  - AWS_REGION=us-east-1
-app:
-  build: app
-  links:
-    - db:db
-  restart: always
-  volumes:
-    - ./volumes/app/mattermost/config:/mattermost/config:rw
-    - ./volumes/app/mattermost/data:/mattermost/data:rw
-    - /etc/localtime:/etc/localtime:ro
-web:
-  build: web
-  ports:
-    - "80:80"
-    - "443:443"
-  links:
-    - app:app
-  restart: always
-  volumes:
-      # This directory must have cert files
-    - ./volumes/web/cert:/cert:ro
-    - /etc/localtime:/etc/localtime:ro
-  environment:
-    - MATTERMOST_ENABLE_SSL=false
-    - PLATFORM_PORT_80_TCP_PORT=80
+version: '2.1'
+services:
+  db:
+    build: db
+    restart: always
+    volumes:
+      - ./volumes/db/var/lib/postgresql/data:/var/lib/postgresql/data
+      - /etc/localtime:/etc/localtime:ro
+    # uncomment the following to enable backup
+    environment:
+      - MM_USERNAME=mmuser
+      - MM_PASSWORD=mmuser_password
+      - MM_DBNAME=mattermost
+    #  - AWS_ACCESS_KEY_ID=XXXX
+    #  - AWS_SECRET_ACCESS_KEY=XXXX
+    #  - WALE_S3_PREFIX=s3://BUCKET_NAME/PATH
+    #  - AWS_REGION=us-east-1
+  app:
+    build: app
+    links:
+      - db:db
+    restart: always
+    volumes:
+      - ./volumes/app/mattermost/config:/mattermost/config:rw
+      - ./volumes/app/mattermost/data:/mattermost/data:rw
+      - /etc/localtime:/etc/localtime:ro
+  web:
+    build: web
+    ports:
+      - "80:80"
+      - "443:443"
+    links:
+      - app:app
+    restart: always
+    volumes:
+        # This directory must have cert files
+      - ./volumes/web/cert:/cert:ro
+      - /etc/localtime:/etc/localtime:ro
+    environment:
+      - MATTERMOST_ENABLE_SSL=false
+      - PLATFORM_PORT_80_TCP_PORT=80


### PR DESCRIPTION
I needed to use the build arg feature, which is only available in recent docker-compose versions.