### PR TITLE
Updating Dockerfile for Mattermost 3.6.2

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:14.04
 RUN apt-get update && apt-get -y install curl netcat
 RUN mkdir -p /mattermost/data
 
-RUN curl https://releases.mattermost.com/3.6.1/mattermost-team-3.6.1-linux-amd64.tar.gz | tar -xvz
+RUN curl https://releases.mattermost.com/3.6.2/mattermost-team-3.6.2-linux-amd64.tar.gz | tar -xvz
 
 RUN rm /mattermost/config/config.json
 COPY config.template.json /


### PR DESCRIPTION
Recommended security update.