### PR TITLE
set db setting on app also

### DIFF
--- a/docker-compose-v1.yml
+++ b/docker-compose-v1.yml
@@ -22,6 +22,12 @@ app:
     - ./volumes/app/mattermost/config:/mattermost/config:rw
     - ./volumes/app/mattermost/data:/mattermost/data:rw
     - /etc/localtime:/etc/localtime:ro
+  environment:
+  # set same as db environment
+    - MM_USERNAME=mmuser
+    - MM_PASSWORD=mmuser_password
+    - MM_DBNAME=mattermost
+
 web:
   build: web
   ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,11 @@ services:
       - ./volumes/app/mattermost/config:/mattermost/config:rw
       - ./volumes/app/mattermost/data:/mattermost/data:rw
       - /etc/localtime:/etc/localtime:ro
+    environment:
+      # set same as db environment
+      - MM_USERNAME=mmuser
+      - MM_PASSWORD=mmuser_password
+      - MM_DBNAME=mattermost
 
   web:
     build: web


### PR DESCRIPTION
- db setting is available on db
- app also uses same valiables (eg. MM_USERNAME...)  however there is no hint on compose file.

```bash
# on mattermost-docker/app/docker-entry.sh
#!/bin/bash
config=/mattermost/config/config.json
DB_HOST=${DB_HOST:-db}
DB_PORT_5432_TCP_PORT=${DB_PORT_5432_TCP_PORT:-5432}

MM_USERNAME=${MM_USERNAME:-mmuser}
MM_PASSWORD=${MM_PASSWORD:-mmuser_password}
MM_DBNAME=${MM_DBNAME:-mattermost}
```

app also uses MM_USERNAME, MM_PASSWORD and MM_DBNAME however there is no hint on compose file.  If I change these value on db compose setting, I have to change app too. So I add some hint on docker-compose.yml. 
