### PR TITLE
Move enterprise version into this branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+
+# Elastic Beanstalk Files
+.elasticbeanstalk/*
+!.elasticbeanstalk/*.cfg.yml
+!.elasticbeanstalk/*.global.yml
+
+# Generated data
+volumes

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This project enables deployment of a Mattermost server in a multi-node productio
 [![Build Status](https://travis-ci.org/mattermost/mattermost-docker.svg?branch=master)](https://travis-ci.org/mattermost/mattermost-docker)
 
 Notes:
+- The default Mattermost edition for this repo has changed from team edition to enterprise edition. Please see [Choose Edition](#choose-edition-to-install) section.
 - To install this Docker project on AWS Elastic Beanstalk please see [AWS Elastic Beanstalk Guide](./README.aws.md).
 - To install Mattermost without Docker directly onto a Linux-based operating systems, please see [Admin Guide](https://docs.mattermost.com/guides/administrator.html#installing-mattermost).
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,16 @@ The following instructions deploy Mattermost in a production configuration using
 * [docker]
 * [docker-compose]
 
+### Choose Edition to Install
+
+If you want to install enterprise edition, you can skip this section.
+
+To install the team edition, comment out the following line in docker-compose.yaml file:
+
+    ```
+    dockerfile: Dockerfile-enterprise
+    ```
+
 ### Database
 
 Make sure to set the appropriate values for `MM_USERNAME`, `MM_PASSWORD` and `MM_DBNAME`.
@@ -27,40 +37,23 @@ Make sure to set the appropriate values for `MM_USERNAME`, `MM_PASSWORD` and `MM
    no password as `./volumes/web/cert/key-no-password.pem`. If you don't have
    them you may generate a self-signed SSL certificate.
 
-3. Build and run mattermost
-
-    ```
-    docker-compose up -d
-    ```
-
-4. Open `https://your.domain` with your web browser.
-
-### Install without SSL certificate
-
-1. Open docker-compose.yml and set `MATTERMOST_ENABLE_SSL` to false.
-
-    ```
-    environment:
-      - MATTERMOST_ENABLE_SSL=false
-    ```
-
 2. Build and run mattermost
 
     ```
     docker-compose up -d
     ```
 
-3. Open `http://your.domain` with your web browser.
+3. Open `https://your.domain` with your web browser.
 
-### Install the Enterprise Version
+### Install without SSL certificate
 
-To install the enterprise version, uncomment the following line in docker-compose.yaml file:
+1. Build and run mattermost
 
     ```
-    dockerfile: Dockerfile-enterprise
+    docker-compose up -d
     ```
 
-Then follow the instruction above.
+2. Open `http://your.domain` with your web browser.
 
 ## Starting/Stopping
 

--- a/README.md
+++ b/README.md
@@ -29,17 +29,38 @@ Make sure to set the appropriate values for `MM_USERNAME`, `MM_PASSWORD` and `MM
 
 3. Build and run mattermost
 
+    ```
     docker-compose up -d
+    ```
 
 4. Open `https://your.domain` with your web browser.
 
 ### Install without SSL certificate
 
-1. Build and run mattermost
+1. Open docker-compose.yml and set `MATTERMOST_ENABLE_SSL` to false.
 
+    ```
+    environment:
+      - MATTERMOST_ENABLE_SSL=false
+    ```
+
+2. Build and run mattermost
+
+    ```
     docker-compose up -d
+    ```
 
 3. Open `http://your.domain` with your web browser.
+
+### Install the Enterprise Version
+
+To install the enterprise version, uncomment the following line in docker-compose.yaml file:
+
+    ```
+    dockerfile: Dockerfile-enterprise
+    ```
+
+Then follow the instruction above.
 
 ## Starting/Stopping
 

--- a/app/Dockerfile-enterprise
+++ b/app/Dockerfile-enterprise
@@ -1,9 +1,13 @@
 FROM ubuntu:14.04
 
+ENV PATH="/mattermost/bin:${PATH}"
+
 RUN apt-get update && apt-get -y install curl netcat
 RUN mkdir -p /mattermost/data
 
-RUN curl https://releases.mattermost.com/3.6.2/mattermost-3.6.2-linux-amd64.tar.gz | tar -xvz
+ENV MM_VERSION=3.6.2
+
+RUN curl https://releases.mattermost.com/$MM_VERSION/mattermost-$MM_VERSION-linux-amd64.tar.gz | tar -xvz
 
 RUN rm /mattermost/config/config.json
 COPY config.template.json /
@@ -13,3 +17,8 @@ RUN chmod +x /docker-entry.sh
 ENTRYPOINT ["/docker-entry.sh"]
 
 EXPOSE 80
+
+VOLUME /mattermost/data
+
+WORKDIR /mattermost/bin
+CMD ["platform"]

--- a/app/Dockerfile-enterprise
+++ b/app/Dockerfile-enterprise
@@ -1,0 +1,15 @@
+FROM ubuntu:14.04
+
+RUN apt-get update && apt-get -y install curl netcat
+RUN mkdir -p /mattermost/data
+
+RUN curl https://releases.mattermost.com/3.6.2/mattermost-3.6.2-linux-amd64.tar.gz | tar -xvz
+
+RUN rm /mattermost/config/config.json
+COPY config.template.json /
+
+COPY docker-entry.sh /
+RUN chmod +x /docker-entry.sh
+ENTRYPOINT ["/docker-entry.sh"]
+
+EXPOSE 80

--- a/docker-compose-v1.yml
+++ b/docker-compose-v1.yml
@@ -4,11 +4,11 @@ db:
   volumes:
     - ./volumes/db/var/lib/postgresql/data:/var/lib/postgresql/data
     - /etc/localtime:/etc/localtime:ro
-  # uncomment the following to enable backup
   environment:
     - POSTGRES_USER=mmuser
     - POSTGRES_PASSWORD=mmuser_password
     - POSTGRES_DB=mattermost
+  # uncomment the following to enable backup
   #  - AWS_ACCESS_KEY_ID=XXXX
   #  - AWS_SECRET_ACCESS_KEY=XXXX
   #  - WALE_S3_PREFIX=s3://BUCKET_NAME/PATH
@@ -16,7 +16,10 @@ db:
   #  in case your config is not in default location
   #  - MM_CONFIG=/mattermost/config/config.jso
 app:
-  build: app
+  build:
+    context: app
+    # comment out for team version
+    dockerfile: Dockerfile-enterprise
   links:
     - db:db
   restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,11 +8,11 @@ services:
     volumes:
       - ./volumes/db/var/lib/postgresql/data:/var/lib/postgresql/data
       - /etc/localtime:/etc/localtime:ro
-    # uncomment the following to enable backup
     environment:
       - POSTGRES_USER=mmuser
       - POSTGRES_PASSWORD=mmuser_password
       - POSTGRES_DB=mattermost
+    # uncomment the following to enable backup
     #  - AWS_ACCESS_KEY_ID=XXXX
     #  - AWS_SECRET_ACCESS_KEY=XXXX
     #  - WALE_S3_PREFIX=s3://BUCKET_NAME/PATH
@@ -21,7 +21,10 @@ services:
     #  - MM_CONFIG=/mattermost/config/config.jso
 
   app:
-    build: app
+    build:
+      context: app
+      # uncomment for enterprise version
+      #dockerfile: Dockerfile-enterprise
     restart: unless-stopped
     volumes:
       - ./volumes/app/mattermost/config:/mattermost/config:rw

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,8 +23,8 @@ services:
   app:
     build:
       context: app
-      # uncomment for enterprise version
-      #dockerfile: Dockerfile-enterprise
+      # comment out for team edition
+      dockerfile: Dockerfile-enterprise
     restart: unless-stopped
     volumes:
       - ./volumes/app/mattermost/config:/mattermost/config:rw


### PR DESCRIPTION
Since the only difference is mattermost package and  we don't want
to maintain two difference branches, just moved the enterprise version
into a alternative dockerfile