### PR TITLE
 add log dir volume option on docker-compose file

### DIFF
--- a/docker-compose-v1.yml
+++ b/docker-compose-v1.yml
@@ -21,6 +21,7 @@ app:
   volumes:
     - ./volumes/app/mattermost/config:/mattermost/config:rw
     - ./volumes/app/mattermost/data:/mattermost/data:rw
+    - ./volumes/app/mattermost/logs:/mattermost/logs:rw
     - /etc/localtime:/etc/localtime:ro
   environment:
   # set same as db environment

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,7 @@ services:
     volumes:
       - ./volumes/app/mattermost/config:/mattermost/config:rw
       - ./volumes/app/mattermost/data:/mattermost/data:rw
+      - ./volumes/app/mattermost/logs:/mattermost/logs:rw
       - /etc/localtime:/etc/localtime:ro
     environment:
       # set same as db environment


### PR DESCRIPTION
If people use mattermost-docker compose file on their production environment, they may want to maintain  their log. 

