### PR TITLE
Install libssl-dev and libffi-dev for db

### DIFF
--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -1,10 +1,10 @@
 FROM postgres:9.4
 
 RUN apt-get update \
-    && apt-get install -y python-dev lzop pv daemontools curl build-essential \
+    && apt-get install -y python-dev lzop pv daemontools curl build-essential libssl-dev libffi-dev \
     && curl --silent --show-error --retry 5 https://bootstrap.pypa.io/get-pip.py | python \
     && pip install 'wal-e<1.0.0' \
-    && apt-get remove -y build-essential python-dev \
+    && apt-get remove -y build-essential python-dev libssl-dev libffi-dev \
     && apt-get autoremove -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*


### PR DESCRIPTION
Otherwise, wal-e fails to build.

~~~~
  ----------------------------------------
  Failed building wheel for cryptography
  Running setup.py clean for cryptography
  Complete output from command /usr/bin/python -u -c "import setuptools, tokenize;__file__='/tmp/pip-build-2lGAUM/cryptography/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" clean --all:
  c/_cffi_backend.c:15:17: fatal error: ffi.h: No such file or directory
   #include <ffi.h>
                   ^
  compilation terminated.
~~~~
*snip*
~~~~
    x86_64-linux-gnu-gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -fno-strict-aliasing -D_FORTIFY_SOURCE=2 -g -fstack-protector-strong -Wformat -Werror=format-security -fPIC -I/usr/include/python2.7 -c build/temp.linux-x86_64-2.7/_openssl.c -o build/temp.linux-x86_64-2.7/build/temp.linux-x86_64-2.7/_openssl.o
    build/temp.linux-x86_64-2.7/_openssl.c:434:30: fatal error: openssl/opensslv.h: No such file or directory
     #include <openssl/opensslv.h>
                                  ^
    compilation terminated.
    error: command 'x86_64-linux-gnu-gcc' failed with exit status 1
    
    ----------------------------------------
~~~~