### PR TITLE
fix build error on Ubuntu 14.04

### DIFF
--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -1,7 +1,7 @@
 FROM postgres:9.4
 
 RUN apt-get update \
-    && apt-get install -y python-dev lzop pv daemontools curl build-essential \
+    && apt-get install -y python-dev libssl-dev lzop pv daemontools curl build-essential \
     && curl --silent --show-error --retry 5 https://bootstrap.pypa.io/get-pip.py | python \
     && pip install 'wal-e<1.0.0' \
     && apt-get remove -y build-essential python-dev \

--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -1,7 +1,7 @@
 FROM postgres:9.4
 
 RUN apt-get update \
-    && apt-get install -y python-dev libssl-dev lzop pv daemontools curl build-essential \
+    && apt-get install -y python-dev libffi-dev libssl-dev lzop pv daemontools curl build-essential \
     && curl --silent --show-error --retry 5 https://bootstrap.pypa.io/get-pip.py | python \
     && pip install 'wal-e<1.0.0' \
     && apt-get remove -y build-essential python-dev \


### PR DESCRIPTION
libssl-dev is needed to be installed on Ubuntu or the build won't be succeed.