### PR TITLE
Fix Dockerrun.aws.json so that it works with the latest docker setup

### DIFF
--- a/Dockerrun.aws.json
+++ b/Dockerrun.aws.json
@@ -14,13 +14,48 @@
             }
         },
         {
+            "name": "app-logs",
+            "host": {
+                "sourcePath": "/var/app/current/app/mattermost/logs"
+            }
+        },
+        {
             "name": "db-data",
             "host": {
                 "sourcePath": "/var/app/current/db/mattermost/var/lib/postgresql/data"
             }
+        },
+        {
+            "name": "web-cert",
+            "host": {
+                "sourcePath": "/var/app/current/web/cert"
+            }
         }
     ],
     "containerDefinitions": [
+        {
+            "name": "db",
+            "image": "mattermost/mattermost-prod-db:latest",
+            "memory": 128,
+            "mountPoints": [
+                {
+                    "sourceVolume": "db-data",
+                    "containerPath": "/var/lib/postgresql/data"
+                }
+            ],
+            "environment": [
+              {
+                "name": "POSTGRES_USER",
+                "value": "mmuser"
+              }, {
+                "name": "POSTGRES_PASSWORD",
+                "value": "mmuser_password"
+              }, {
+                "name": "POSTGRES_DB",
+                "value": "mattermost"
+              }
+            ]
+        },
         {
             "name": "app",
             "image": "mattermost/mattermost-prod-app:latest",
@@ -33,12 +68,10 @@
                 {
                     "sourceVolume": "app-data",
                     "containerPath": "/mattermost/data"
-                }
-            ],
-            "portMappings": [
+                },
                 {
-                    "hostPort": 80,
-                    "containerPort": 80
+                    "sourceVolume": "app-logs",
+                    "containerPath": "/mattermost/logs"
                 }
             ],
             "links": [
@@ -46,14 +79,27 @@
             ]
         },
         {
-            "name": "db",
-            "image": "mattermost/mattermost-prod-db:latest",
+            "name": "web",
+            "image": "mattermost/mattermost-prod-web:latest",
             "memory": 128,
             "mountPoints": [
                 {
-                    "sourceVolume": "db-data",
-                    "containerPath": "/var/lib/postgresql/data"
+                    "sourceVolume": "web-cert",
+                    "containerPath": "/cert"
                 }
+            ],
+            "portMappings": [
+                {
+                    "hostPort": 80,
+                    "containerPort": 80
+                },
+                {
+                    "hostPort": 443,
+                    "containerPort": 443
+                }
+            ],
+            "links": [
+                "app"
             ]
         }
     ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
     build:
       context: app
       # comment out for team edition
-      # dockerfile: Dockerfile-enterprise
+      dockerfile: Dockerfile-enterprise
     restart: unless-stopped
     volumes:
       - ./volumes/app/mattermost/config:/mattermost/config:rw

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
     build:
       context: app
       # comment out for team edition
-      dockerfile: Dockerfile-enterprise
+      # dockerfile: Dockerfile-enterprise
     restart: unless-stopped
     volumes:
       - ./volumes/app/mattermost/config:/mattermost/config:rw


### PR DESCRIPTION
The current Dockerrun.aws.json is about a year old and no longer works. I believe I've fixed the issues and would like to have this committed to the repo. 