### PR TITLE
Do not use env variables to override APP conf. (fix #136)

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -4,25 +4,11 @@ FROM ubuntu:14.04
 ENV PATH="/mattermost/bin:${PATH}"
 ENV MM_VERSION=3.9.0
 
-# Override default config
-ENV MM_SERVICESETTINGS_LISTENADDRESS=":80" \
-    MM_LOGSETTINGS_ENABLECONSOLE=false \
-    MM_LOGSETTINGS_CONSOLELEVEL="INFO" \
-    MM_FILESETTINGS_DIRECTORY="/mattermost/data/" \
-    MM_FILESETTINGS_ENABLEPUBLICLINK=true \
-    MM_FILESETTINGS_PUBLICLINKSALT="A705AklYF8MFDOfcwh3I488G8vtLlVip" \
-    MM_EMAILSETTINGS_SENDEMAILNOTIFICATIONS=false \
-    MM_EMAILSETTINGS_FEEDBACKEMAIL="" \
-    MM_EMAILSETTINGS_SMTPSERVER="" \
-    MM_EMAILSETTINGS_SMTPPORT="" \
-    MM_EMAILSETTINGS_INVITESALT="bjlSR4QqkXFBr7TP4oDzlfZmcNuH9YoS" \
-    MM_RATELIMITSETTINGS_ENABLE=true \
-    MM_SQLSETTINGS_DRIVERNAME="postgres"
-
 # Install some needed packages
 RUN apt-get update \
     && apt-get -y install \
       curl \
+      jq \
       netcat \
     && rm -rf /var/lib/apt/lists/*
 

--- a/app/Dockerfile-enterprise
+++ b/app/Dockerfile-enterprise
@@ -4,25 +4,11 @@ FROM ubuntu:14.04
 ENV PATH="/mattermost/bin:${PATH}"
 ENV MM_VERSION=3.9.0
 
-# Override default config
-ENV MM_SERVICESETTINGS_LISTENADDRESS=":80" \
-    MM_LOGSETTINGS_ENABLECONSOLE=false \
-    MM_LOGSETTINGS_CONSOLELEVEL="INFO" \
-    MM_FILESETTINGS_DIRECTORY="/mattermost/data/" \
-    MM_FILESETTINGS_ENABLEPUBLICLINK=true \
-    MM_FILESETTINGS_PUBLICLINKSALT="A705AklYF8MFDOfcwh3I488G8vtLlVip" \
-    MM_EMAILSETTINGS_SENDEMAILNOTIFICATIONS=false \
-    MM_EMAILSETTINGS_FEEDBACKEMAIL="" \
-    MM_EMAILSETTINGS_SMTPSERVER="" \
-    MM_EMAILSETTINGS_SMTPPORT="" \
-    MM_EMAILSETTINGS_INVITESALT="bjlSR4QqkXFBr7TP4oDzlfZmcNuH9YoS" \
-    MM_RATELIMITSETTINGS_ENABLE=true \
-    MM_SQLSETTINGS_DRIVERNAME="postgres"
-
 # Install some needed packages
 RUN apt-get update \
     && apt-get -y install \
       curl \
+      jq \
       netcat \
     && rm -rf /var/lib/apt/lists/*
 

--- a/app/docker-entry.sh
+++ b/app/docker-entry.sh
@@ -20,10 +20,29 @@ if [ "$1" = 'platform' ]; then
         esac
     done
 
-    echo "Using config file" $MM_CONFIG
+
     if [ ! -f $MM_CONFIG ]
     then
-        cp /config.json.save $MM_CONFIG
+      echo "No configuration file" $MM_CONFIG
+      echo "Creating a new one"
+      # Copy default configuration file
+      cp /config.json.save $MM_CONFIG
+      # Substitue some parameters with jq
+      jq '.ServiceSettings.ListenAddress = ":80"' $MM_CONFIG > $MM_CONFIG.tmp && mv $MM_CONFIG.tmp $MM_CONFIG
+      jq '.LogSettings.EnableConsole = false' $MM_CONFIG > $MM_CONFIG.tmp && mv $MM_CONFIG.tmp $MM_CONFIG
+      jq '.LogSettings.ConsoleLevel = "INFO"' $MM_CONFIG > $MM_CONFIG.tmp && mv $MM_CONFIG.tmp $MM_CONFIG
+      jq '.FileSettings.Directory = "/mattermost/data/"' $MM_CONFIG > $MM_CONFIG.tmp && mv $MM_CONFIG.tmp $MM_CONFIG
+      jq '.FileSettings.EnablePublicLink = true' $MM_CONFIG > $MM_CONFIG.tmp && mv $MM_CONFIG.tmp $MM_CONFIG
+      jq '.FileSettings.PublicLinkSalt = "A705AklYF8MFDOfcwh3I488G8vtLlVip"' $MM_CONFIG > $MM_CONFIG.tmp && mv $MM_CONFIG.tmp $MM_CONFIG
+      jq '.EmailSettings.SendEmailNotifications = false' $MM_CONFIG > $MM_CONFIG.tmp && mv $MM_CONFIG.tmp $MM_CONFIG
+      jq '.EmailSettings.FeedbackEmail = ""' $MM_CONFIG > $MM_CONFIG.tmp && mv $MM_CONFIG.tmp $MM_CONFIG
+      jq '.EmailSettings.SMTPServer = ""' $MM_CONFIG > $MM_CONFIG.tmp && mv $MM_CONFIG.tmp $MM_CONFIG
+      jq '.EmailSettings.SMTPPort = ""' $MM_CONFIG > $MM_CONFIG.tmp && mv $MM_CONFIG.tmp $MM_CONFIG
+      jq '.EmailSettings.InviteSalt = "bjlSR4QqkXFBr7TP4oDzlfZmcNuH9YoS"' $MM_CONFIG > $MM_CONFIG.tmp && mv $MM_CONFIG.tmp $MM_CONFIG
+      jq '.RateLimitSettings.Enable = true' $MM_CONFIG > $MM_CONFIG.tmp && mv $MM_CONFIG.tmp $MM_CONFIG
+      jq '.SqlSettings.DriverName = "postgres"' $MM_CONFIG > $MM_CONFIG.tmp && mv $MM_CONFIG.tmp $MM_CONFIG
+    else
+      echo "Using existing config file" $MM_CONFIG
     fi
 
     echo -ne "Configure database connection..."


### PR DESCRIPTION
PR #131 introduced a **big** issue which cause Mattermost app to not be configurable (as described on #136).
It seems that using environment variables to modify the default Mattermost configuration (as described [here](https://docs.mattermost.com/administration/config-settings.html)) is not a really good idea. Instead, Mattermost app should have the following behavior :
- if a `config.json` file already exists (using volumes mount), do not modify configuration. Only override database connection (since it **should** be done by passing environment vars to app container)
- if there is no `config.json` use the default one and change some vars using `jq`

I run test locally and it respect this behavior. Looks good to me.
@xcompass @br00tal