### PR TITLE
Use links instead of depends_on

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,8 +36,8 @@ services:
       - MM_USERNAME=mmuser
       - MM_PASSWORD=mmuser_password
       - MM_DBNAME=mattermost
-    depends_on:
-      - db
+    links:
+      - db:db
 
   web:
     build: web
@@ -49,5 +49,5 @@ services:
       # This directory must have cert files
       - ./volumes/web/cert:/cert:ro
       - /etc/localtime:/etc/localtime:ro
-    depends_on:
-      - app
+    links:
+      - app:app


### PR DESCRIPTION
In `docker-compose.yml` file, I think it should be better to use `links` instead of `depends_on` by default. It will allow to change services names (like in https://github.com/mattermost/mattermost-docker/issues/142#issuecomment-309374431 ) without breaking containers which hardcode `app` and `db` hostnames.