### PR TITLE
Move to docker-compose v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ The following instructions deploy Mattermost in a production configuration using
 * [docker]
 * [docker-compose]
 
+The `docker-compose.yml` file use Docker Compose `3.0+` format (which require Docker `1.13.0+`). If you want to use previous version of Docker or Docker Compose, you should modify the `version` field on the `docker-compose.yml` file.
+
 ### Choose Edition to Install
 
 If you want to install enterprise edition, you can skip this section.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "2"
+version: "3"
 
 services:
 


### PR DESCRIPTION
Should allow support for docker stack. #104

We should have no issue with the `docker-compose.yml` file itself there is no changes on options we use.
The only concern is that [it seems to required](https://docs.docker.com/compose/compose-file/compose-versioning/#compatibility-matrix) at least Docker Engine `1.13.0` which is quite recent and, AFAIK,  not yet on Ubuntu official repositories.

Maybe we should add a second docker-compose file for v3 ?