### PR TITLE
Only configure database connection if needed

### DIFF
--- a/app/docker-entry.sh
+++ b/app/docker-entry.sh
@@ -51,9 +51,14 @@ if [ "$1" = 'platform' ]; then
       echo "Using existing config file" $MM_CONFIG
     fi
 
-    echo -ne "Configure database connection..."
-    export MM_SQLSETTINGS_DATASOURCE="postgres://$MM_USERNAME:$MM_PASSWORD@$DB_HOST:$DB_PORT_NUMBER/$MM_DBNAME?sslmode=disable&connect_timeout=10"
-    echo OK
+    if [ -z "$MM_SQLSETTINGS_DATASOURCE"]
+    then
+      echo -ne "Configure database connection..."
+      export MM_SQLSETTINGS_DATASOURCE="postgres://$MM_USERNAME:$MM_PASSWORD@$DB_HOST:$DB_PORT_NUMBER/$MM_DBNAME?sslmode=disable&connect_timeout=10"
+      echo OK
+    else
+      echo "Using existing database connection"
+    fi
 
     echo "Wait until database $DB_HOST:$DB_PORT_NUMBER is ready..."
     until nc -z $DB_HOST $DB_PORT_NUMBER


### PR DESCRIPTION
This allows MySQL users to predefine a custom `MM_SQLSETTINGS_DATASOURCE`, which needed for the database connection. 

In the official [docs](https://docs.mattermost.com/install/install-ubuntu-1604.html#installing-mattermost-server) the following connection „string“ is mentioned for MySQL users: 

```
"mmuser:<mmuser-password>@tcp(<host-name-or-IP>:3306)/mattermost?charset=utf8mb4,utf8&readTimeout=30s&writeTimeout=30s
```

Without this change the container forces the Mattermost server to use a Postgres connection, even if the config file defines MySQL.