### PR TITLE
Upgrade to 4.3.0

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:14.04
 
 # Some ENV variables
 ENV PATH="/mattermost/bin:${PATH}"
-ENV MM_VERSION=4.2.0
+ENV MM_VERSION=4.3.0
 
 # Build argument to set Mattermost edition
 ARG edition=entreprise


### PR DESCRIPTION
Mattermost `4.3.0` will be released on October 16th.

Changelog is [here](https://docs.mattermost.com/administration/changelog.html?highlight=changelog#release-v4-3-0).