### PR TITLE
Remove deprecated links in docker-compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,8 +37,6 @@ services:
       - MM_DBNAME=mattermost
       # in case your config is not in default location
       #- MM_CONFIG=/mattermost/config/config.json
-    links:
-      - db:db
 
   web:
     build: web
@@ -53,5 +51,3 @@ services:
     # Uncomment for SSL
     # environment:
     #  - MATTERMOST_ENABLE_SSL=true
-    links:
-      - app:app


### PR DESCRIPTION
Using links is considered to be a deprecated feature of Docker,
in favor of user-defined networks (see
https://docs.docker.com/engine/userguide/networking/default_network/dockerlinks/).

Since the docker-compose file is in Version 2, a network is
automatically created for the 3 containers, making them accessible to each others with their name directly.