### PR TITLE
Add version 4.0.5

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:14.04
 
 # Some ENV variables
 ENV PATH="/mattermost/bin:${PATH}"
-ENV MM_VERSION=4.3.1
+ENV MM_VERSION=4.0.5
 
 # Build argument to set Mattermost edition
 ARG edition=entreprise


### PR DESCRIPTION
We need to upgrade to 4.0.5 for now. Here is the change log: https://docs.mattermost.com/administration/changelog.html#release-v4-0-5