### PR TITLE
[FIX] URLEncode PSQL Password

### DIFF
--- a/app/entrypoint.sh
+++ b/app/entrypoint.sh
@@ -58,7 +58,9 @@ if [ "$1" = 'platform' ]; then
   if [ -z "$MM_SQLSETTINGS_DATASOURCE" ]
   then
     echo -ne "Configure database connection..."
-    export MM_SQLSETTINGS_DATASOURCE="postgres://$MM_USERNAME:$MM_PASSWORD@$DB_HOST:$DB_PORT_NUMBER/$MM_DBNAME?sslmode=disable&connect_timeout=10"
+    # URLEncode the password, allowing for special characters
+    ENCODED_PASSWORD=$(printf %s $MM_PASSWORD | jq -s -R -r @uri)
+    export MM_SQLSETTINGS_DATASOURCE="postgres://$MM_USERNAME:$ENCODED_PASSWORD@$DB_HOST:$DB_PORT_NUMBER/$MM_DBNAME?sslmode=disable&connect_timeout=10"
     echo OK
   else
     echo "Using existing database connection"


### PR DESCRIPTION
* URL Encode the Postgres password, allowing for special characters in the connection string.

This uses Python to do the quoting, which is available in Ubuntu by default. If #208 is being considered, we'll either need to install Python in that or adapt the implementation here.
  