### PR TITLE
Fix broken link

### DIFF
--- a/web/mattermost-ssl
+++ b/web/mattermost-ssl
@@ -55,4 +55,4 @@ server {
     }
 }
 
-# See https://github.com/mattermost/docs/blob/master/source/install/prod-ubuntu.rst for the SSL configuration
+# See https://docs.mattermost.com/install/install-ubuntu-1604.html#configuring-nginx-with-ssl-and-http-2 for the SSL configuration


### PR DESCRIPTION
Fix 404 broken link.

---

There is something I want to confirm.

This fixing and [More Information](https://github.com/mattermost/mattermost-docker#more-information) in README are pointing mattermost docs about ubuntu-**14.04**.
Is it right? should be point ubuntu-**16.04**?
