### PR TITLE
Non root user for mattermost app

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,10 @@ install:
 
 env:
     - BUILD="docker-compose up -d"
-    - BUILD="docker run -d --name db -e POSTGRES_USER=mmuser -e POSTGRES_PASSWORD=mmuser_password -e POSTGRES_DB=mattermost mattermost-prod-db && sleep 5 && docker run -d --link db -p 80:80 --name app mattermost-prod-app"
+    - BUILD="docker run -d --name db -e POSTGRES_USER=mmuser -e POSTGRES_PASSWORD=mmuser_password -e POSTGRES_DB=mattermost mattermost-prod-db && sleep 5 && docker run -d --link db -p 8000:8000 --name app mattermost-prod-app"
 
 script:
-    - curl -sSf http://localhost > /dev/null
+    - curl -sSf http://localhost:8000 > /dev/null
 
 after_failure:
     - timeout 3s docker-compose logs app db web

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -6,26 +6,38 @@ ENV MM_VERSION=4.6.1
 
 # Build argument to set Mattermost edition
 ARG edition=enterprise
+ARG PUID=1000
+ARG PGID=1000
 
 # Install some needed packages
 RUN apk add --no-cache \
-	ca-certificates \
-	curl \
-	jq \
-	libc6-compat \
-	libffi-dev \
-	linux-headers \
-	mailcap \
-	netcat-openbsd \
-	xmlsec-dev \
-	&& rm -rf /tmp/*
+    ca-certificates \
+    curl \
+    jq \
+    libc6-compat \
+    libffi-dev \
+    linux-headers \
+    mailcap \
+    netcat-openbsd \
+    xmlsec-dev \
+    && rm -rf /tmp/*
 
 # Get Mattermost
 RUN mkdir -p /mattermost/data \
     && if [ "$edition" = "team" ] ; then curl https://releases.mattermost.com/$MM_VERSION/mattermost-team-$MM_VERSION-linux-amd64.tar.gz | tar -xvz ; \
       else curl https://releases.mattermost.com/$MM_VERSION/mattermost-$MM_VERSION-linux-amd64.tar.gz | tar -xvz ; fi \
     && cp /mattermost/config/config.json /config.json.save \
-    && rm -rf /mattermost/config/config.json
+    && rm -Rf /mattermost/config/config.json 
+
+# Get ready for production
+RUN addgroup -g ${PGID} mattermost \
+    && adduser -D -u ${PUID} -G mattermost mattermost \
+    && chown -R mattermost: /mattermost \
+    && apk update \
+    && apk del curl \
+    && rm -rf /tmp/* 
+
+USER mattermost
 
 # Configure entrypoint and command
 COPY entrypoint.sh /
@@ -33,8 +45,8 @@ ENTRYPOINT ["/entrypoint.sh"]
 WORKDIR /mattermost
 CMD ["platform"]
 
-# Expose port 80 of the container
-EXPOSE 80
+# Expose port 8000 of the container
+EXPOSE 8000
 
 # Use a volume for the data directory
 VOLUME /mattermost/data

--- a/app/entrypoint.sh
+++ b/app/entrypoint.sh
@@ -35,7 +35,7 @@ if [ "$1" = 'platform' ]; then
     # Copy default configuration file
     cp /config.json.save $MM_CONFIG
     # Substitue some parameters with jq
-    jq '.ServiceSettings.ListenAddress = ":80"' $MM_CONFIG > $MM_CONFIG.tmp && mv $MM_CONFIG.tmp $MM_CONFIG
+    jq '.ServiceSettings.ListenAddress = ":8000"' $MM_CONFIG > $MM_CONFIG.tmp && mv $MM_CONFIG.tmp $MM_CONFIG
     jq '.LogSettings.EnableConsole = false' $MM_CONFIG > $MM_CONFIG.tmp && mv $MM_CONFIG.tmp $MM_CONFIG
     jq '.LogSettings.ConsoleLevel = "INFO"' $MM_CONFIG > $MM_CONFIG.tmp && mv $MM_CONFIG.tmp $MM_CONFIG
     jq '.FileSettings.Directory = "/mattermost/data/"' $MM_CONFIG > $MM_CONFIG.tmp && mv $MM_CONFIG.tmp $MM_CONFIG

--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update \
     && apt-get remove -y \
       build-essential \
       python-dev \
+      curl \
     && apt-get autoremove -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*.deb /var/cache/apt/archives/partial/*.deb /var/cache/apt/*.bin /tmp/* /var/tmp/*

--- a/web/entrypoint.sh
+++ b/web/entrypoint.sh
@@ -2,7 +2,7 @@
 
 # Define default value for app container hostname and port
 APP_HOST=${APP_HOST:-app}
-APP_PORT_NUMBER=${APP_PORT_NUMBER:-80}
+APP_PORT_NUMBER=${APP_PORT_NUMBER:-8000}
 
 # Check if SSL should be enabled (if certificates exists)
 if [ -f "/cert/cert.pem" -a -f "/cert/key-no-password.pem" ]; then


### PR DESCRIPTION
Hi, 

Running a containerized application with a root user is not a best practice as if the container is breached out, the attacker is able to get a root access on your Docker host. 
The user UID and GID is configurable via ARG during the build process. 
As a non root user is not able to bind port less than 1024, I modified the web container to use the 8000 port instead of 80. 

Regards, 