### PR TITLE
updating link about install instruction for Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,4 +175,4 @@ For the server configurations, see [prod-ubuntu.rst] of Mattermost.
 
 [docker]: http://docs.docker.com/engine/installation/
 [docker-compose]: https://docs.docker.com/compose/install/
-[prod-ubuntu.rst]: https://docs.mattermost.com/install/install-ubuntu-1404.html
+[prod-ubuntu.rst]: https://docs.mattermost.com/install/install-ubuntu-1604.html


### PR DESCRIPTION
Updating link about the install instruction for Ubuntu from `14.04` to `16.04`.
Be same as the other page(refs #227).