### PR TITLE
Upgrade mattermost to 4.9.0

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.6
 
 # Some ENV variables
 ENV PATH="/mattermost/bin:${PATH}"
-ENV MM_VERSION=4.8.1
+ENV MM_VERSION=4.9.0
 
 # Build argument to set Mattermost edition
 ARG edition=enterprise


### PR DESCRIPTION
Release: https://github.com/mattermost/mattermost-server/releases/tag/v4.9.0

Changelog: https://github.com/mattermost/docs/blob/e55503f1633027b67be727eebfe04530eaa67180/source/administration/changelog.md#release-v49