### PR TITLE
Backup plugins directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
     - sleep 30
 
 env:
-    - BUILD="mkdir -p ./volumes/app/mattermost/{data,logs,config} && docker-compose up -d"
+    - BUILD="mkdir -p ./volumes/app/mattermost/{data,logs,config,plugins} && docker-compose up -d"
     - BUILD="docker run -d --name db -e POSTGRES_USER=mmuser -e POSTGRES_PASSWORD=mmuser_password -e POSTGRES_DB=mattermost mattermost-prod-db && sleep 5 && docker run -d --link db -p 80:8000 --name app mattermost-prod-app"
 
 script:

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ them you may generate a self-signed SSL certificate.
 #### Start
 If you are running docker with non root user, make sure the UID and GID in app/Dockerfile are the same as your current UID/GID
 ```
-mkdir -p ./volumes/app/mattermost/{data,logs,config}
+mkdir -p ./volumes/app/mattermost/{data,logs,config,plugins}
 chown -R 2000:2000 ./volumes/app/mattermost/
 docker-compose start
 ```
@@ -158,7 +158,7 @@ Docker images for `4.9.0` release introduce some important changes from [PR #241
 
 One important change is that we don't use `root` user by default to run the Mattermost application. So, as explained on [the README](https://github.com/mattermost/mattermost-docker#start), if you use host mounted volume you have to be sure that files on your host server have the correct UID/GID (by default those values are `2000`). In practice, you should just run following commands :
 ```
-mkdir -p ./volumes/app/mattermost/{data,logs,config}
+mkdir -p ./volumes/app/mattermost/{data,logs,config,plugins}
 chown -R 2000:2000 ./volumes/app/mattermost/
 ```
 
@@ -191,7 +191,7 @@ Running containerized applications on multi-node swarms involves specific data p
 
 First, create mattermost directory structure on the docker hosts:
 ```
-mkdir -p /var/lib/mattermost/{cert,config,data,logs}
+mkdir -p /var/lib/mattermost/{cert,config,data,logs,plugins}
 ```
 
 Then, fire up the stack in your swarm:

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -50,4 +50,4 @@ CMD ["mattermost"]
 EXPOSE 8000
 
 # Declare volumes for mount point directories
-VOLUME ["/mattermost/data", "/mattermost/logs", "/mattermost/config"]
+VOLUME ["/mattermost/data", "/mattermost/logs", "/mattermost/config", "/mattermost/plugins"]

--- a/app/entrypoint.sh
+++ b/app/entrypoint.sh
@@ -50,6 +50,7 @@ if [ "$1" = 'mattermost' ]; then
     jq '.RateLimitSettings.Enable = true' $MM_CONFIG > $MM_CONFIG.tmp && mv $MM_CONFIG.tmp $MM_CONFIG
     jq '.SqlSettings.DriverName = "postgres"' $MM_CONFIG > $MM_CONFIG.tmp && mv $MM_CONFIG.tmp $MM_CONFIG
     jq '.SqlSettings.AtRestEncryptKey = "'$(generate_salt)'"' $MM_CONFIG > $MM_CONFIG.tmp && mv $MM_CONFIG.tmp $MM_CONFIG
+    jq '.PluginSettings.Directory = "/mattermost/plugins/"' $MM_CONFIG > $MM_CONFIG.tmp && mv $MM_CONFIG.tmp $MM_CONFIG
   else
     echo "Using existing config file" $MM_CONFIG
   fi

--- a/contrib/aws/Dockerrun.aws.json
+++ b/contrib/aws/Dockerrun.aws.json
@@ -20,6 +20,12 @@
             }
         },
         {
+            "name": "app-plugins",
+            "host": {
+                "sourcePath": "/var/app/current/app/mattermost/plugins"
+            }
+        },
+        {
             "name": "db-data",
             "host": {
                 "sourcePath": "/var/app/current/db/mattermost/var/lib/postgresql/data"
@@ -72,6 +78,10 @@
                 {
                     "sourceVolume": "app-logs",
                     "containerPath": "/mattermost/logs"
+                },
+                {
+                    "sourceVolume": "app-plugins",
+                    "containerPath": "/mattermost/plugins"
                 }
             ],
             "links": [

--- a/contrib/swarm/docker-stack-traefik.yml
+++ b/contrib/swarm/docker-stack-traefik.yml
@@ -67,6 +67,7 @@ services:
       - /var/lib/mattermost/config:/mattermost/config:rw
       - /var/lib/mattermost/data:/mattermost/data:rw
       - /var/lib/mattermost/logs:/mattermost/logs:rw
+      - /var/lib/mattermost/plugins:/mattermost/plugins:rw
       - /etc/localtime:/etc/localtime:ro
     environment:
       # use service's hostname

--- a/contrib/swarm/docker-stack.yml
+++ b/contrib/swarm/docker-stack.yml
@@ -66,6 +66,7 @@ services:
       - /var/lib/mattermost/config:/mattermost/config:rw
       - /var/lib/mattermost/data:/mattermost/data:rw
       - /var/lib/mattermost/logs:/mattermost/logs:rw
+      - /var/lib/mattermost/plugins:/mattermost/plugins:rw
       - /etc/localtime:/etc/localtime:ro
     environment:
       # use service's hostname

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,7 @@ services:
       - ./volumes/app/mattermost/config:/mattermost/config:rw
       - ./volumes/app/mattermost/data:/mattermost/data:rw
       - ./volumes/app/mattermost/logs:/mattermost/logs:rw
+      - ./volumes/app/mattermost/plugins:/mattermost/plugins:rw
       - /etc/localtime:/etc/localtime:ro
     environment:
       # set same as db credentials and dbname


### PR DESCRIPTION
Now, volumes settings doesn't include `plugins` directory.
So when recreating containers, all plugins will be removed.

I think that it had better to add `plugins` directory to volumes settings.