### PR TITLE
add volume for client/plugins

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -48,4 +48,4 @@ CMD ["mattermost"]
 EXPOSE 8000
 
 # Declare volumes for mount point directories
-VOLUME ["/mattermost/data", "/mattermost/logs", "/mattermost/config", "/mattermost/plugins"]
+VOLUME ["/mattermost/data", "/mattermost/logs", "/mattermost/config", "/mattermost/plugins", "/mattermost/client/plugins"]


### PR DESCRIPTION
using the new plugin feature there are two volumes one for the /mattermost/plugin which is for the server side and the /mattermost/client/plugins for the webapp part.

