### PR TITLE
add ability to build your own mm binary

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -8,6 +8,7 @@ ENV MM_VERSION=5.3.1
 ARG edition=enterprise
 ARG PUID=2000
 ARG PGID=2000
+ARG MM_BINARY=
 
 
 # Install some needed packages
@@ -25,7 +26,8 @@ RUN apk add --no-cache \
 
 # Get Mattermost
 RUN mkdir -p /mattermost/data \
-    && if [ "$edition" = "team" ] ; then curl https://releases.mattermost.com/$MM_VERSION/mattermost-team-$MM_VERSION-linux-amd64.tar.gz | tar -xvz ; \
+    && if [ ! -z "$MM_BINARY" ]; then curl $MM_BINARY | tar -xvz ; \
+      elif [ "$edition" = "team" ] ; then curl https://releases.mattermost.com/$MM_VERSION/mattermost-team-$MM_VERSION-linux-amd64.tar.gz | tar -xvz ; \
       else curl https://releases.mattermost.com/$MM_VERSION/mattermost-$MM_VERSION-linux-amd64.tar.gz | tar -xvz ; fi \
     && cp /mattermost/config/config.json /config.json.save \
     && rm -rf /mattermost/config/config.json \


### PR DESCRIPTION
We will start building this Image for both team and enterprise version from master and release branches

to achieve that we need to be able to point to any build we need.

