### PR TITLE
Remove DB check in the app/entrypoint

### DIFF
--- a/app/entrypoint.sh
+++ b/app/entrypoint.sh
@@ -67,16 +67,6 @@ if [ "$1" = 'mattermost' ]; then
     echo "Using existing config file" $MM_CONFIG
   fi
 
-  if [ -z "$MM_SQLSETTINGS_DATASOURCE" ] && [ ! -f $MM_CONFIG ]
-  then
-    # Wait for database to be reachable
-    echo "Wait until database $DB_HOST:$DB_PORT_NUMBER is ready..."
-    until nc -z $DB_HOST $DB_PORT_NUMBER
-    do
-      sleep 1
-    done
-  fi
-
   # Wait another second for the database to be properly started.
   # Necessary to avoid "panic: Failed to open sql connection pq: the database system is starting up"
   sleep 1

--- a/app/entrypoint.sh
+++ b/app/entrypoint.sh
@@ -67,7 +67,7 @@ if [ "$1" = 'mattermost' ]; then
     echo "Using existing config file" $MM_CONFIG
   fi
 
-  if [ ! -z "$DB_HOST" ]
+  if [ -z "$MM_SQLSETTINGS_DATASOURCE" ] && [ ! -f $MM_CONFIG ]
   then
     # Wait for database to be reachable
     echo "Wait until database $DB_HOST:$DB_PORT_NUMBER is ready..."


### PR DESCRIPTION
just realize that this PR https://github.com/mattermost/mattermost-docker/pull/315 checks the variable DB and db exist always we need to check if a config or the MM_SQLSETTINGS_DATASOURCE not set