### PR TITLE
replace port 8000 to the default one and add gossip and stream ports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ install:
 
 env:
     - BUILD="mkdir -p ./volumes/app/mattermost/{data,logs,config,plugins} && docker-compose up -d"
-    - BUILD="docker run -d --name db -e POSTGRES_USER=mmuser -e POSTGRES_PASSWORD=mmuser_password -e POSTGRES_DB=mattermost mattermost-prod-db && sleep 5 && docker run -d --link db -p 80:8000 --name app mattermost-prod-app"
+    - BUILD="docker run -d --name db -e POSTGRES_USER=mmuser -e POSTGRES_PASSWORD=mmuser_password -e POSTGRES_DB=mattermost mattermost-prod-db && sleep 5 && docker run -d --link db -p 80:8065 --name app mattermost-prod-app"
 
 script:
     - curl -sSf http://localhost > /dev/null

--- a/README.md
+++ b/README.md
@@ -152,9 +152,9 @@ docker-compose up -d
 
 Your Docker image should now be on the latest Mattermost version.
 
-## Upgrading Mattermost to 5.5.0+
+## Upgrading Mattermost to 6.0.0+
 
-Docker images for `5.5.0` release introduce a new change related to the way to access the application, We switch back the application port to use the default port which is `8065`. Existing installations that use port `8000` will not work without a little configuration change. You have to open your Mattermost configuration file (`./volumes/app/mattermost/config/config.json` by default) and change the key `ServiceSettings.ListenAddress` to `:8065`.
+Docker images for `6.0.0` release introduce a new change related to the way to access the application, We switch back the application port to use the default port which is `8065`. Existing installations that use port `8000` will not work without a little configuration change. You have to open your Mattermost configuration file (`./volumes/app/mattermost/config/config.json` by default) and change the key `ServiceSettings.ListenAddress` to `:8065`.
 Also if you use your own web-server/reverse-proxy you need to change its configuration to reach port `8065` of the Mattermost container.
 
 Also added two new ports for HA installations which is the GossipPort `8074` and the StreamingPort `8075`.

--- a/README.md
+++ b/README.md
@@ -152,6 +152,12 @@ docker-compose up -d
 
 Your Docker image should now be on the latest Mattermost version.
 
+## Upgrading Mattermost to 5.5.0+
+
+Docker images for `5.5.0` release introduce a new change related to the way to access the application, We switch back the application port to use the default port which is `8065`. Existing installations that use port `8000` will not work without a little configuration change. You have to open your Mattermost configuration file (`./volumes/app/mattermost/config/config.json` by default) and change the key `ServiceSettings.ListenAddress` to `:8065`.
+Also if you use your own web-server/reverse-proxy you need to change its configuration to reach port `8065` of the Mattermost container.
+
+Also added two new ports for HA installations which is the GossipPort `8074` and the StreamingPort `8075`.
 
 ## Upgrading Mattermost to 4.9+
 

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -38,7 +38,7 @@ RUN mkdir -p /mattermost/data \
 USER mattermost
 
 #Healthcheck to make sure container is ready
-HEALTHCHECK CMD curl --fail http://localhost:8000 || exit 1
+HEALTHCHECK CMD curl --fail http://localhost:8065 || exit 1
 
 # Configure entrypoint and command
 COPY entrypoint.sh /
@@ -46,8 +46,8 @@ ENTRYPOINT ["/entrypoint.sh"]
 WORKDIR /mattermost
 CMD ["mattermost"]
 
-# Expose port 8000 of the container
-EXPOSE 8000
+# Expose Mattermost App, GossipPort, StreamingPort
+EXPOSE 8065 8074 8075
 
 # Declare volumes for mount point directories
 VOLUME ["/mattermost/data", "/mattermost/logs", "/mattermost/config", "/mattermost/plugins", "/mattermost/client/plugins"]

--- a/app/entrypoint.sh
+++ b/app/entrypoint.sh
@@ -35,7 +35,6 @@ if [ "$1" = 'mattermost' ]; then
     # Copy default configuration file
     cp /config.json.save $MM_CONFIG
     # Substitue some parameters with jq
-    jq '.ServiceSettings.ListenAddress = ":8000"' $MM_CONFIG > $MM_CONFIG.tmp && mv $MM_CONFIG.tmp $MM_CONFIG
     jq '.LogSettings.EnableConsole = false' $MM_CONFIG > $MM_CONFIG.tmp && mv $MM_CONFIG.tmp $MM_CONFIG
     jq '.LogSettings.ConsoleLevel = "INFO"' $MM_CONFIG > $MM_CONFIG.tmp && mv $MM_CONFIG.tmp $MM_CONFIG
     jq '.FileSettings.Directory = "/mattermost/data/"' $MM_CONFIG > $MM_CONFIG.tmp && mv $MM_CONFIG.tmp $MM_CONFIG

--- a/contrib/kubernetes/mattermost.svc.yaml
+++ b/contrib/kubernetes/mattermost.svc.yaml
@@ -6,8 +6,8 @@ metadata:
 spec:
   type: NodePort
   ports:
-  - port: 80
-    targetPort: 80
+  - port: 8065
+    targetPort: 8065
     protocol: TCP
     name: http
   selector:

--- a/contrib/swarm/docker-stack-traefik.yml
+++ b/contrib/swarm/docker-stack-traefik.yml
@@ -4,17 +4,17 @@
 # Simply run:
 #
 # `docker stack up [STACK NAME] -c docker-stack-traefik.yml`
-# 
+#
 # In this case `mm` is going to be stack name, so the command will be:
 #
 # `docker stack up mm -c docker-stack-traefik.yml`
 #
 # From now on all the services that belong to this stack will be prefixed with `mm_`
 # this file defines 3 services, these are going to be mm_db, mm_app and mm_web,
-# each of these names is the service's hostname as well, they can communicate 
+# each of these names is the service's hostname as well, they can communicate
 # with each other easily by using the hostname instead of the ip or exposing ports to the host.
 #
-# As a side note, images tagged as latest are pulled by default, 
+# As a side note, images tagged as latest are pulled by default,
 # that means there's no need to use `image:latest`
 #
 # use latest compose v3.3 file format for optimal compatibility with latest docker release and swarm features.

--- a/contrib/swarm/docker-stack.yml
+++ b/contrib/swarm/docker-stack.yml
@@ -4,17 +4,17 @@
 # Simply run:
 #
 # `docker stack up [STACK NAME] -c docker-stack.yml`
-# 
+#
 # In this case `mm` is going to be stack name, so the command will be:
 #
 # `docker stack up mm -c docker-stack.yml`
 #
 # From now on all the services that belong to this stack will be prefixed with `mm_`
 # this file defines 3 services, these are going to be mm_db, mm_app and mm_web,
-# each of these names is the service's hostname as well, they can communicate 
+# each of these names is the service's hostname as well, they can communicate
 # with each other easily by using the hostname instead of the ip or exposing ports to the host.
 #
-# As a side note, images tagged as latest are pulled by default, 
+# As a side note, images tagged as latest are pulled by default,
 # that means there's no need to use `image:latest`
 #
 # use latest compose v3.3 file format for optimal compatibility with latest docker release and swarm features.

--- a/web/entrypoint.sh
+++ b/web/entrypoint.sh
@@ -2,7 +2,7 @@
 
 # Define default value for app container hostname and port
 APP_HOST=${APP_HOST:-app}
-APP_PORT_NUMBER=${APP_PORT_NUMBER:-8000}
+APP_PORT_NUMBER=${APP_PORT_NUMBER:-8065}
 
 # Check if SSL should be enabled (if certificates exists)
 if [ -f "/cert/cert.pem" -a -f "/cert/key-no-password.pem" ]; then

--- a/web/security.conf
+++ b/web/security.conf
@@ -16,7 +16,7 @@ add_header X-Frame-Options SAMEORIGIN;
 add_header X-Content-Type-Options nosniff;
 
 # This header enables the Cross-site scripting (XSS) filter built into most recent web browsers.
-# It's usually enabled by default anyway, so the role of this header is to re-enable the filter for 
+# It's usually enabled by default anyway, so the role of this header is to re-enable the filter for
 # this particular website if it was disabled by the user.
 # https://www.owasp.org/index.php/List_of_useful_HTTP_headers
 add_header X-XSS-Protection "1; mode=block";


### PR DESCRIPTION
Replacing the 8000 to use the default port for Mattermost, with that we don't need to change the configuration and make it more standard with other apps

this was a question from Christopher and I already thought on that, and it makes sense to use the default one because in the host you can select any port.

cc
@pichouk @crspeller @jwilander 