### PR TITLE
downgrade alpine to 3.7 due xmlsec1 issues

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8
+FROM alpine:3.7
 
 # Some ENV variables
 ENV PATH="/mattermost/bin:${PATH}"


### PR DESCRIPTION
Downgrade to alpine 3.7 to fix the xmlsec1 issues describe here: https://github.com/mattermost/mattermost-docker/issues/309


also, we use saml in the pre-release and using this alpine:3.8 broken the integration