### PR TITLE
Allow acme challenge through NGINX configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,6 +53,7 @@ services:
       # This directory must have cert files if you want to enable SSL
       - ./volumes/web/cert:/cert:ro
       - /etc/localtime:/etc/localtime:ro
+      - ./volumes/web/acme-challenge:/var/www/acme-challenge:ro
     # Uncomment for SSL
     # environment:
     #  - MATTERMOST_ENABLE_SSL=true

--- a/web/mattermost
+++ b/web/mattermost
@@ -36,4 +36,10 @@ server {
         proxy_read_timeout 600s;
         proxy_pass http://{%APP_HOST%}:{%APP_PORT%};
     }
+
+    location /.well-known/acme-challenge/ {
+        default_type "text/plain";
+        root         /var/www/acme-challenge;
+        rewrite /.well-known/acme-challenge/(.*)$ /$1 break;
+    }
 }

--- a/web/mattermost-ssl
+++ b/web/mattermost-ssl
@@ -1,7 +1,14 @@
 server {
 	listen 80 default_server;
 	server_name _;
+    location / {
 	return 301 https://$host$request_uri;
+    }
+    location /.well-known/acme-challenge/ {
+        default_type "text/plain";
+        root         /var/www/acme-challenge;
+        rewrite /.well-known/acme-challenge/(.*)$ /$1 break;
+    }
 }
 
 map $http_x_forwarded_proto $proxy_x_forwarded_proto {


### PR DESCRIPTION
In docker production, the SSL certificate is enabled through NGINX configuration. It would be convenient to ease the integration of *let's encrypt*  certificates by allowing to expise acme challenge files through HTTP (`http://host:port/.well-known/acme-challenge/<challenge file>`).

This merge request is a proposal to enable this through an additional docker volume for the web component (`./volumes/web/acme-challenge`).