### PR TITLE
Break traefik command in multiple lines

### DIFF
--- a/contrib/swarm/docker-stack-traefik.yml
+++ b/contrib/swarm/docker-stack-traefik.yml
@@ -109,7 +109,18 @@ services:
       - "443:443"
     networks:
       - mm-out
-    command: --acme --acme.email="[ADD YOUR EMAIL HERE]" --acme.entrypoint=https --acme.onhostrule --acme.storage="acme/certs.json" --acme.acmelogging --web --docker --docker.domain=docker.localhost --docker.swarmmode --docker.watch --logLevel=DEBUG
+    command: >
+      --acme
+      --acme.email="[ADD YOUR EMAIL HERE]"
+      --acme.entrypoint=https --acme.onhostrule
+      --acme.storage="acme/certs.json"
+      --acme.acmelogging
+      --web
+      --docker
+      --docker.domain=docker.localhost
+      --docker.swarmmode
+      --docker.watch
+      --logLevel=DEBUG
     volumes:
       # traefik needs the docker socket in order to work properly
       - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
Hello,

The traefik command is pretty long. You can use yaml folded style:
- Each line break is replaced by a space.
- The indention in each line will be ignored
- A line break will be inserted at the end.
Which keep the current behaviour