### PR TITLE
include timezone for plugins that use location information.

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -22,6 +22,7 @@ RUN apk add --no-cache \
 	mailcap \
 	netcat-openbsd \
 	xmlsec-dev \
+	tzdata \
 	&& rm -rf /tmp/*
 
 # Get Mattermost


### PR DESCRIPTION
There has been [some issues](https://github.com/scottleedavis/mattermost-plugin-remind/issues/88) with running a plugin that uses time.In(location), where location is loaded by tzdata information.  

http://pouzek.si/blog/go-loadlocation-docker/

This PR adds the tzdata apk to the app container
