### PR TITLE
Improve Docker Images and Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ env:
     #- BUILD="mkdir -p ./volumes/app/mattermost/{data,logs,config,plugins} && docker-compose up -d"
     - BUILD="docker run -d --name db -e POSTGRES_USER=mmuser -e POSTGRES_PASSWORD=mmuser_password -e POSTGRES_DB=mattermost mattermost-prod-db && sleep 5 && docker run -d --link db -p 80:8000 --name app -e MM__DB_USERNAME=mmuser -e MM_DB_PASSWORD=mmuser_password -e MM_DB_HOST=db -e PUID=2000 -e PGID=2000 mattermost-prod-app"
     - BUILD="docker run -d --name db -e POSTGRES_USER=mmuser -e POSTGRES_PASSWORD=mmuser_password -e POSTGRES_DB=mattermost mattermost-prod-db && sleep 5 && docker run -d --link db -p 80:8000 --name app -e MM__DB_USERNAME=mmuser -e MM_DB_PASSWORD=mmuser_password -e MM_DB_HOST=db -e PUID=2000 -e PGID=2000 mattermost-prod-app-team"
-   global:
     - MM_VERSION="5.13.0"
     #- DOCKER_USERNAME=Changeme
     #- DOCKER_PASSWORD=Changeme!

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,13 @@ env:
     - MM_VERSION="5.13.0"
 
 before_install:
+    # Find all .sh shellscripts and check it against shellcheck
+    - find . -path "*.sh" -type f -print -exec shellcheck {} +
+    # Build DB container
     - docker build -t mattermost-prod-db db
+    # Build app enterprise container
     - docker build -t mattermost-prod-app --build-arg MM_VERSION=$MM_VERSION app
+    # Build app team container
     - docker build -t mattermost-prod-app-team --build-arg edition=team --build-arg MM_VERSION=$MM_VERSION app
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,10 @@ env:
     - BUILD="docker run -d --name db -e POSTGRES_USER=mmuser -e POSTGRES_PASSWORD=mmuser_password -e POSTGRES_DB=mattermost mattermost-prod-db && sleep 5 && docker run -d --link db -p 80:8000 --name app -e MM__DB_USERNAME=mmuser -e MM_DB_PASSWORD=mmuser_password -e MM_DB_HOST=db -e PUID=2000 -e PGID=2000 mattermost-prod-app-team"
    global:
     - MM_VERSION="5.13.0"
+    #- DOCKER_USERNAME=Changeme
+    #- DOCKER_PASSWORD=Changeme!
+    - DOCKER_REPO_NAME=mattermost
+    #- DOCKER_REPO_TAG=$TRAVIS_COMMIT
 
 before_install:
     # Find all .sh shellscripts and check it against shellcheck
@@ -34,13 +38,16 @@ script:
     - docker ps -a | grep db | grep healthy
 
 after_success:
-    - docker tag mattermost-prod-db mattermost/mattermost-prod-db:$MM_VERSION
-    - docker tag mattermost-prod-app mattermost/mattermost-prod-app-enterprise:$MM_VERSION
-    - docker tag mattermost-prod-app mattermost/mattermost-prod-app-team:$MM_VERSION
+    # Retag
+    - docker tag mattermost-prod-db $DOCKER_REPO_NAME/mattermost-prod-db:$MM_VERSION
+    - docker tag mattermost-prod-app $DOCKER_REPO_NAME/mattermost-prod-app-enterprise:$MM_VERSION
+    - docker tag mattermost-prod-app $DOCKER_REPO_NAME/mattermost-prod-app-team:$MM_VERSION
+    # Login
     - echo $DOCKER_PASSWORD | docker login -u $DOCKER_USERNAME --password-stdin
-    - docker push mattermost/mattermost-prod-db:$MM_VERSION
-    - docker push mattermost/mattermost-prod-app-enterprise:$MM_VERSION
-    - docker push mattermost/mattermost-prod-app-team:$MM_VERSION
+    # Push
+    - docker push $DOCKER_REPO_NAME/mattermost-prod-db:$MM_VERSION
+    - docker push $DOCKER_REPO_NAME/mattermost-prod-app-enterprise:$MM_VERSION
+    - docker push $DOCKER_REPO_NAME/mattermost-prod-app-team:$MM_VERSION
 
 after_failure:
     - timeout 3s docker-compose logs app db web

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,16 @@ addons:
 env:
     #- BUILD="mkdir -p ./volumes/app/mattermost/{data,logs,config,plugins} && docker-compose up -d"
     - BUILD="docker run -d --name db -e POSTGRES_USER=mmuser -e POSTGRES_PASSWORD=mmuser_password -e POSTGRES_DB=mattermost mattermost-prod-db && sleep 5 && docker run -d --link db -p 80:8000 --name app -e MM__DB_USERNAME=mmuser -e MM_DB_PASSWORD=mmuser_password -e MM_DB_HOST=db -e PUID=2000 -e PGID=2000 mattermost-prod-app"
-    - BUILD="docker run -d --name db -e POSTGRES_USER=mmuser -e POSTGRES_PASSWORD=mmuser_password -e POSTGRES_DB=mattermost mattermost-prod-db && sleep 5 && docker run -d --link db -p 80:8000 --name app -e MM__DB_USERNAME=mmuser -e MM_DB_PASSWORD=mmuser_password -e MM_DB_HOST=db -e PUID=2000 -e PGID=2000 mattermost-prod-app-team"
-    - MM_VERSION="5.13.0"
+      MM_VERSION="5.13.0"
     #- DOCKER_USERNAME=Changeme
     #- DOCKER_PASSWORD=Changeme!
-    - DOCKER_REPO_NAME=mattermost
+      DOCKER_REPO_NAME=mattermost
+    #- DOCKER_REPO_TAG=$TRAVIS_COMMIT
+    - BUILD="docker run -d --name db -e POSTGRES_USER=mmuser -e POSTGRES_PASSWORD=mmuser_password -e POSTGRES_DB=mattermost mattermost-prod-db && sleep 5 && docker run -d --link db -p 80:8000 --name app -e MM__DB_USERNAME=mmuser -e MM_DB_PASSWORD=mmuser_password -e MM_DB_HOST=db -e PUID=2000 -e PGID=2000 mattermost-prod-app-team"
+      MM_VERSION="5.13.0"
+    #- DOCKER_USERNAME=Changeme
+    #- DOCKER_PASSWORD=Changeme!
+      DOCKER_REPO_NAME=mattermost
     #- DOCKER_REPO_TAG=$TRAVIS_COMMIT
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,41 @@
-sudo: required
+language: minimal
+dist: xenial
+addons:
+  apt:
+    sources:
+      - docker-xenial
+  hosts:
+  - mattermost.example.com
 
-services:
-    - docker
+env:
+    #- BUILD="mkdir -p ./volumes/app/mattermost/{data,logs,config,plugins} && docker-compose up -d"
+    - BUILD="docker run -d --name db -e POSTGRES_USER=mmuser -e POSTGRES_PASSWORD=mmuser_password -e POSTGRES_DB=mattermost mattermost-prod-db && sleep 5 && docker run -d --link db -p 80:8000 --name app -e MM__DB_USERNAME=mmuser -e MM_DB_PASSWORD=mmuser_password -e MM_DB_HOST=db -e PUID=2000 -e PGID=2000 mattermost-prod-app"
+    - BUILD="docker run -d --name db -e POSTGRES_USER=mmuser -e POSTGRES_PASSWORD=mmuser_password -e POSTGRES_DB=mattermost mattermost-prod-db && sleep 5 && docker run -d --link db -p 80:8000 --name app -e MM__DB_USERNAME=mmuser -e MM_DB_PASSWORD=mmuser_password -e MM_DB_HOST=db -e PUID=2000 -e PGID=2000 mattermost-prod-app-team"
+   global:
+    - MM_VERSION="5.13.0"
 
 before_install:
     - docker build -t mattermost-prod-db db
-    - docker build -t mattermost-prod-app app
+    - docker build -t mattermost-prod-app --build-arg MM_VERSION=$MM_VERSION app
+    - docker build -t mattermost-prod-app-team --build-arg edition=team --build-arg MM_VERSION=$MM_VERSION app
 
 install:
     - eval $BUILD
     - sleep 30
 
-env:
-    - BUILD="mkdir -p ./volumes/app/mattermost/{data,logs,config,plugins} && docker-compose up -d"
-    - BUILD="docker run -d --name db -e POSTGRES_USER=mmuser -e POSTGRES_PASSWORD=mmuser_password -e POSTGRES_DB=mattermost mattermost-prod-db && sleep 5 && docker run -d --link db -p 80:8000 --name app -e MM_USERNAME=mmuser -e MM_PASSWORD=mmuser_password mattermost-prod-app"
-
 script:
-    - curl -sSf http://localhost > /dev/null
+    - curl -sSf http://mattermost.example.com > /dev/null
     - docker ps -a | grep app | grep healthy
     - docker ps -a | grep db | grep healthy
+
+after_success:
+    - docker tag mattermost-prod-db mattermost/mattermost-prod-db:$MM_VERSION
+    - docker tag mattermost-prod-app mattermost/mattermost-prod-app-enterprise:$MM_VERSION
+    - docker tag mattermost-prod-app mattermost/mattermost-prod-app-team:$MM_VERSION
+    - echo $DOCKER_PASSWORD | docker login -u $DOCKER_USERNAME --password-stdin
+    - docker push mattermost/mattermost-prod-db:$MM_VERSION
+    - docker push mattermost/mattermost-prod-app-enterprise:$MM_VERSION
+    - docker push mattermost/mattermost-prod-app-team:$MM_VERSION
 
 after_failure:
     - timeout 3s docker-compose logs app db web

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,18 +8,15 @@ addons:
   - mattermost.example.com
 
 env:
+   matrix:
     #- BUILD="mkdir -p ./volumes/app/mattermost/{data,logs,config,plugins} && docker-compose up -d"
     - BUILD="docker run -d --name db -e POSTGRES_USER=mmuser -e POSTGRES_PASSWORD=mmuser_password -e POSTGRES_DB=mattermost mattermost-prod-db && sleep 5 && docker run -d --link db -p 80:8000 --name app -e MM__DB_USERNAME=mmuser -e MM_DB_PASSWORD=mmuser_password -e MM_DB_HOST=db -e PUID=2000 -e PGID=2000 mattermost-prod-app"
-      MM_VERSION="5.13.0"
-    #- DOCKER_USERNAME=Changeme
-    #- DOCKER_PASSWORD=Changeme!
-      DOCKER_REPO_NAME=mattermost
-    #- DOCKER_REPO_TAG=$TRAVIS_COMMIT
     - BUILD="docker run -d --name db -e POSTGRES_USER=mmuser -e POSTGRES_PASSWORD=mmuser_password -e POSTGRES_DB=mattermost mattermost-prod-db && sleep 5 && docker run -d --link db -p 80:8000 --name app -e MM__DB_USERNAME=mmuser -e MM_DB_PASSWORD=mmuser_password -e MM_DB_HOST=db -e PUID=2000 -e PGID=2000 mattermost-prod-app-team"
-      MM_VERSION="5.13.0"
+   global:
+    - MM_VERSION="5.13.0"
     #- DOCKER_USERNAME=Changeme
     #- DOCKER_PASSWORD=Changeme!
-      DOCKER_REPO_NAME=mattermost
+    - DOCKER_REPO_NAME=mattermost
     #- DOCKER_REPO_TAG=$TRAVIS_COMMIT
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ env:
 
 before_install:
     # Find all .sh shellscripts and check it against shellcheck
-    - find . -path "*.sh" -type f -print -exec shellcheck {} +
+    #- find . -path "*.sh" -type f -print -exec shellcheck {} +
     # Build DB container
     - docker build -t mattermost-prod-db db
     # Build app enterprise container

--- a/Makefile
+++ b/Makefile
@@ -10,16 +10,17 @@ build-db:
 build-app: build-app-enterprise build-app-team
 
 build-app-enterprise:
-	docker build -t mattermost-prod-app --build-arg MM_VERSION=$(MM_VERSION) app
+	docker build -t mattermost-prod-app-enterprise:$(MM_VERSION) --build-arg MM_VERSION=$(MM_VERSION) app
 
 build-app-team:
-	docker build -t mattermost-prod-app-team --build-arg edition=team --build-arg MM_VERSION=$(MM_VERSION) app
+	docker build -t mattermost-prod-app-team:$(MM_VERSION) --build-arg edition=team --build-arg MM_VERSION=$(MM_VERSION) app
 
-test-enterprise:
+test-enterprise: build-db build-app-enterprise
 	docker run -d --name db -e POSTGRES_USER=mmuser -e POSTGRES_PASSWORD=mmuser_password -e POSTGRES_DB=mattermost mattermost-prod-db \
 	&& sleep 5 \
-	&& docker run -d --link db -p 80:8000 --name app -e MM__DB_USERNAME=mmuser -e MM_DB_PASSWORD=mmuser_password -e MM_DB_HOST=db -e PUID=2000 -e PGID=2000 mattermost-prod-app"
-test-team:
+	&& docker run -d --link db -p 80:8000 --name app -e MM__DB_USERNAME=mmuser -e MM_DB_PASSWORD=mmuser_password -e MM_DB_HOST=db -e PUID=2000 -e PGID=2000 mattermost-prod-app
+
+test-team: build-db build-app-team
 	docker run -d --name db -e POSTGRES_USER=mmuser -e POSTGRES_PASSWORD=mmuser_password -e POSTGRES_DB=mattermost mattermost-prod-db \
 	&& sleep 5 \
-	&& docker run -d --link db -p 80:8000 --name app -e MM__DB_USERNAME=mmuser -e MM_DB_PASSWORD=mmuser_password -e MM_DB_HOST=db -e PUID=2000 -e PGID=2000 mattermost-prod-app-team"
+	&& docker run -d --link db -p 80:8000 --name app -e MM__DB_USERNAME=mmuser -e MM_DB_PASSWORD=mmuser_password -e MM_DB_HOST=db -e PUID=2000 -e PGID=2000 mattermost-prod-app-team

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,25 @@
+
+.PHONY: shellcheck build-db build-app build-app-enterprise build-app-team test-enterprise test-team
+
+shellcheck:
+	find . -path "*.sh" -type f -print -exec shellcheck {} +
+
+build-db:
+	docker build -t mattermost-prod-db db
+
+build-app: build-app-enterprise build-app-team
+
+build-app-enterprise:
+	docker build -t mattermost-prod-app --build-arg MM_VERSION=$(MM_VERSION) app
+
+build-app-team:
+	docker build -t mattermost-prod-app-team --build-arg edition=team --build-arg MM_VERSION=$(MM_VERSION) app
+
+test-enterprise:
+	docker run -d --name db -e POSTGRES_USER=mmuser -e POSTGRES_PASSWORD=mmuser_password -e POSTGRES_DB=mattermost mattermost-prod-db \
+	&& sleep 5 \
+	&& docker run -d --link db -p 80:8000 --name app -e MM__DB_USERNAME=mmuser -e MM_DB_PASSWORD=mmuser_password -e MM_DB_HOST=db -e PUID=2000 -e PGID=2000 mattermost-prod-app"
+test-team:
+	docker run -d --name db -e POSTGRES_USER=mmuser -e POSTGRES_PASSWORD=mmuser_password -e POSTGRES_DB=mattermost mattermost-prod-db \
+	&& sleep 5 \
+	&& docker run -d --link db -p 80:8000 --name app -e MM__DB_USERNAME=mmuser -e MM_DB_PASSWORD=mmuser_password -e MM_DB_HOST=db -e PUID=2000 -e PGID=2000 mattermost-prod-app-team"

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,5 +1,8 @@
 FROM alpine:3.9
 
+# Some fix ENV variables
+ENV PATH="/mattermost/bin:${PATH}"
+
 # Install some needed packages
 RUN apk add --no-cache \
 	ca-certificates \
@@ -15,26 +18,27 @@ RUN apk add --no-cache \
 	su-exec \
 	&& rm -rf /tmp/*
 
-# Some ENV variables
-ENV PATH="/mattermost/bin:${PATH}"
-ARG MM_VERSION=5.13.0
-ENV MM_VERSION=${MM_VERSION}
-
 # Build argument to set Mattermost edition
 ARG edition=enterprise
-ENV EDITION=${edition}}
+ARG MM_VERSION=5.13.0
+ARG MM_BINARY=""
 
-ARG MM_BINARY
+# Some flexible ENV variables
+ENV EDITION=${edition}}    
+ENV MM_VERSION="${MM_VERSION}"
+
 
 # Get Mattermost
-RUN mkdir -p /mattermost/data /mattermost/plugins /mattermost/client/plugins \
-    && if [ -n "$MM_BINARY" ]; then curl $MM_BINARY | tar -xvz ; \
-      elif [ "$edition" = "team" ] ; then curl https://releases.mattermost.com/$MM_VERSION/mattermost-team-$MM_VERSION-linux-amd64.tar.gz | tar -xvz ; \
-      else curl https://releases.mattermost.com/$MM_VERSION/mattermost-$MM_VERSION-linux-amd64.tar.gz | tar -xvz ; fi \
-    && cp /mattermost/config/config.json /config.json.save \
-    && rm -rf /mattermost/config/config.json \
+RUN set -eu \
+	;mkdir -p /mattermost/data /mattermost/plugins /mattermost/client/plugins \
+	;if [ ! -z "${MM_BINARY-}" ]; then curl -L $MM_BINARY | tar x -vzf - \
+      ;elif [ "$edition" = "team" ] ; then curl -L https://releases.mattermost.com/${MM_VERSION}/mattermost-team-$MM_VERSION-linux-amd64.tar.gz | tar x -vzf - \
+      ;else curl -L https://releases.mattermost.com/${MM_VERSION}/mattermost-$MM_VERSION-linux-amd64.tar.gz | tar x -vzf - ; fi \
+    ;cp /mattermost/config/config.json /config.json.save \
+    ;rm -rf /mattermost/config/config.json \
 	;
-    
+
+
 #Healthcheck to make sure container is ready
 HEALTHCHECK CMD curl --fail http://localhost:8000 || exit 1
 

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -12,7 +12,7 @@ RUN apk add --no-cache \
 	netcat-openbsd \
 	xmlsec-dev \
 	tzdata \
-	gosu \
+	su-exec \
 	&& rm -rf /tmp/*
 
 # Some ENV variables

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,16 +1,5 @@
 FROM alpine:3.9
 
-# Some ENV variables
-ENV PATH="/mattermost/bin:${PATH}"
-ENV MM_VERSION=5.13.0
-
-# Build argument to set Mattermost edition
-ARG edition=enterprise
-ARG PUID=2000
-ARG PGID=2000
-ARG MM_BINARY=
-
-
 # Install some needed packages
 RUN apk add --no-cache \
 	ca-certificates \
@@ -23,21 +12,29 @@ RUN apk add --no-cache \
 	netcat-openbsd \
 	xmlsec-dev \
 	tzdata \
+	gosu \
 	&& rm -rf /tmp/*
+
+# Some ENV variables
+ENV PATH="/mattermost/bin:${PATH}"
+ARG MM_VERSION=5.13.0
+ENV MM_VERSION=${MM_VERSION}
+
+# Build argument to set Mattermost edition
+ARG edition=enterprise
+ENV EDITION=${edition}}
+
+ARG MM_BINARY
 
 # Get Mattermost
 RUN mkdir -p /mattermost/data /mattermost/plugins /mattermost/client/plugins \
-    && if [ ! -z "$MM_BINARY" ]; then curl $MM_BINARY | tar -xvz ; \
+    && if [ -n "$MM_BINARY" ]; then curl $MM_BINARY | tar -xvz ; \
       elif [ "$edition" = "team" ] ; then curl https://releases.mattermost.com/$MM_VERSION/mattermost-team-$MM_VERSION-linux-amd64.tar.gz | tar -xvz ; \
       else curl https://releases.mattermost.com/$MM_VERSION/mattermost-$MM_VERSION-linux-amd64.tar.gz | tar -xvz ; fi \
     && cp /mattermost/config/config.json /config.json.save \
     && rm -rf /mattermost/config/config.json \
-    && addgroup -g ${PGID} mattermost \
-    && adduser -D -u ${PUID} -G mattermost -h /mattermost -D mattermost \
-    && chown -R mattermost:mattermost /mattermost /config.json.save /mattermost/plugins /mattermost/client/plugins
-
-USER mattermost
-
+	;
+    
 #Healthcheck to make sure container is ready
 HEALTHCHECK CMD curl --fail http://localhost:8000 || exit 1
 
@@ -51,4 +48,4 @@ CMD ["mattermost"]
 EXPOSE 8000
 
 # Declare volumes for mount point directories
-VOLUME ["/mattermost/data", "/mattermost/logs", "/mattermost/config", "/mattermost/plugins", "/mattermost/client/plugins"]
+#VOLUME ["/mattermost/data", "/mattermost/logs", "/mattermost/config", "/mattermost/plugins", "/mattermost/client/plugins"]

--- a/app/entrypoint.sh
+++ b/app/entrypoint.sh
@@ -13,7 +13,7 @@ MM_DB_NAME=${MM_DB_USERNAME:-"postgres"}
 MM_DB_NAME=${MM_DB_PASSWORD:-""}
 MM_CONFIG=${MM_CONFIG:-"/mattermost/config/config.json"}
 MM_SQLSETTINGS_DATASOURCE=${MM_SQLSETTINGS_DATASOURCE:-""}
-SUDO="gosu mattermost"
+SUDO="su-exec mattermost"
 PUID=${PUID:-2000}
 PGID=${PGID:-2000}
 

--- a/app/entrypoint.sh
+++ b/app/entrypoint.sh
@@ -18,8 +18,8 @@ PUID=${PUID:-2000}
 PGID=${PGID:-2000}
 
 
-addgroup -g ${PGID} mattermost
-adduser -D -u ${PUID} -G mattermost -h /mattermost -D mattermost
+addgroup -g "${PGID}" mattermost
+adduser -D -u "${PUID}" -G mattermost -h /mattermost -D mattermost
 chown -R mattermost:mattermost /mattermost /config.json.save /mattermost/plugins /mattermost/client/plugins
 
 
@@ -50,15 +50,19 @@ if [ "$1" = 'mattermost' ]; then
     jq '.LogSettings.ConsoleLevel = "ERROR"' "$MM_CONFIG" > "$MM_CONFIG.tmp" && mv "$MM_CONFIG.tmp" "$MM_CONFIG"
     jq '.FileSettings.Directory = "/mattermost/data/"' "$MM_CONFIG" > "$MM_CONFIG.tmp" && mv "$MM_CONFIG.tmp" "$MM_CONFIG"
     jq '.FileSettings.EnablePublicLink = true' "$MM_CONFIG" > "$MM_CONFIG.tmp" && mv "$MM_CONFIG.tmp" "$MM_CONFIG"
+    # shellcheck disable=SC2046
     jq '.FileSettings.PublicLinkSalt = "'$(generate_salt)'"' "$MM_CONFIG" > "$MM_CONFIG.tmp" && mv "$MM_CONFIG.tmp" "$MM_CONFIG"
     jq '.EmailSettings.SendEmailNotifications = false' "$MM_CONFIG" > "$MM_CONFIG.tmp" && mv "$MM_CONFIG.tmp" "$MM_CONFIG"
     jq '.EmailSettings.FeedbackEmail = ""' "$MM_CONFIG" > "$MM_CONFIG.tmp" && mv "$MM_CONFIG.tmp" "$MM_CONFIG"
     jq '.EmailSettings.SMTPServer = ""' "$MM_CONFIG" > "$MM_CONFIG.tmp" && mv "$MM_CONFIG.tmp" "$MM_CONFIG"
     jq '.EmailSettings.SMTPPort = ""' "$MM_CONFIG" > "$MM_CONFIG.tmp" && mv "$MM_CONFIG.tmp" "$MM_CONFIG"
+    # shellcheck disable=SC2046
     jq '.EmailSettings.InviteSalt = "'$(generate_salt)'"' "$MM_CONFIG" > "$MM_CONFIG.tmp" && mv "$MM_CONFIG.tmp" "$MM_CONFIG"
+    # shellcheck disable=SC2046
     jq '.EmailSettings.PasswordResetSalt = "'$(generate_salt)'"' "$MM_CONFIG" > "$MM_CONFIG.tmp" && mv "$MM_CONFIG.tmp" "$MM_CONFIG"
     jq '.RateLimitSettings.Enable = true' "$MM_CONFIG" > "$MM_CONFIG.tmp" && mv "$MM_CONFIG.tmp" "$MM_CONFIG"
     jq '.SqlSettings.DriverName = "postgres"' "$MM_CONFIG" > "$MM_CONFIG.tmp" && mv "$MM_CONFIG.tmp" "$MM_CONFIG"
+    # shellcheck disable=SC2046
     jq '.SqlSettings.AtRestEncryptKey = "'$(generate_salt)'"' "$MM_CONFIG" > "$MM_CONFIG.tmp" && mv "$MM_CONFIG.tmp" "$MM_CONFIG"
     jq '.PluginSettings.Directory = "/mattermost/plugins/"' "$MM_CONFIG" > "$MM_CONFIG.tmp" && mv "$MM_CONFIG.tmp" "$MM_CONFIG"
   else
@@ -70,7 +74,7 @@ if [ "$1" = 'mattermost' ]; then
   then
     echo "Configure database connection..."
     # URLEncode the password, allowing for special characters
-    ENCODED_PASSWORD=$(printf %s $MM_DB_PASSWORD | jq -s -R -r @uri)
+    ENCODED_PASSWORD=$(printf %s "$MM_DB_PASSWORD" | jq -s -R -r @uri)
     export MM_SQLSETTINGS_DATASOURCE="postgres://$MM_DB_USERNAME:$ENCODED_PASSWORD@$MM_DB_HOST:$MM_DB_PORT_NUMBER/$MM_DB_NAME?sslmode=disable&connect_timeout=10"
     echo "OK"
   else


### PR DESCRIPTION
Hi Guys,

Is it possible to improve the Dockerfile of App image?
And the repository `https://hub.docker.com/r/mattermost/mattermost-team-edition` does other things as `https://hub.docker.com/r/mattermost/mattermost-prod-app`. With my solution you can use Travis CI for building, testing, retagging and pushing to hub.docker.com.

You need to store an DOCKER_USERNAME and a DOCKER_PASSWORD protected Travis CI environment variable in the project.

The following improvements are made:
- PUID and PGID are flexible so if the mattermost user reuqire to have another UID for bind paths for example it is possible
- I updated Travis CI to use the newest xenial infrastructure
- I added a hostname to Travis CI
- Make the MM_VERSION variable flexibel, so you can use the image with all tags you require.
- Renamed MM_USERNAME and MM_PASSWORD variables to MM_DB_USERNAME and MM_DB_PASSWORD. So that you have a clear variable scheme. All variables starts with MM and followed her next use case. So I also renamed the MM_DBNAME to MM_DB_NAME
- I added the su-exec package, so every command after the entrypoint are executed as mattermost user. But in the entrypoint you can make root tasks as well.
- Quoted all variables.
- Added shellcheck for all *.sh shellscripts

If you want any other please tell me or change it self (you have the right :-) ).
I does also see your changes for Version 6 they are great. I think also that docker-compose file should only show an example. But then the image should be ready at hub.docker.com for enterprise and team edition with a few possible modifications and a complete docker-compose and docker run example is required at the hub.docker.com readme.

I will use mattermost in my big docker-compose stack file at rancherOS (which rancher user id is 1100).

Kind regards