### PR TITLE
Remove @pichouk from active maintainers

### DIFF
--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -18,7 +18,6 @@ The following people help to maintain this open source project:
 
 | Current Maintainer(s)                 | Start Date    |
 |:--------------------------------------|:--------------|
-| Kyâne Pichou - @pichouk               | Jun 01 2017   |
 | Carlos Tadeu Panato Junior - @cpanato | Feb 18 2018   |
 
 In case something happens where no maintainers are able to complete their responsibilies, the following sponsoring organization can help find a new maintainer:
@@ -56,10 +55,11 @@ Maintainer(s) should periodically review pull requests and issues submitted to p
 
 PREVIOUS MAINTAINERS
 
-| Maintainer             | Start Date    | End Date    |
-|:-----------------------|:--------------|:------------|
-| Yi EungJun - @npcode   | Nov 26 2015   | Nov 30 2016 |
-| Pan Luo - @xcompass    | Nov 30 2015   | Feb 21 2019 |
+| Maintainer              | Start Date    | End Date    |
+|:------------------------|:--------------|:------------|
+| Yi EungJun - @npcode    | Nov 26 2015   | Nov 30 2016 |
+| Pan Luo - @xcompass     | Nov 30 2015   | Feb 21 2019 |
+| Kyâne Pichou - @pichouk | Jun 01 2017   | Aug 15 2019 |
 
 
 CREATOR


### PR DESCRIPTION
Hi @jasonblais and @cpanato 

Has I said on pre-release, I'm not maintaining this repository anymore, my last activity was several months ago, I'm not able to dedicate time for Mattermost's docker images anymore.
So I just remove myself from maintainers list.

I let you merge the PR, as I think you should remove my write access on the repository at the same time :)