### PR TITLE
update docker-compose version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "2"
+version: "2.2"
 
 services:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "2.2"
+version: "3"
 
 services:
 


### PR DESCRIPTION
### ❗️  Problem
I recently ran into build errors caused by missing proxy configuration. This could be solved by providing the `--build-arg` parameter and setting the needed environment vars.

But this feature was added in the docker-compose file rev. > `2.2`.

### ❓ Analysis
If you try to build the images without the `--build-arg` parameter it throws `DNS resolv` and `permission denied` errors in the `db` image. This is caused by the `apk add` command from the underlying alpine image.

> So you have to provide additional build args in environments where the build takes place behind non transparent proxy. The simplest way is to use the `--build-arg` parameter from docker-compose. Otherwise you would have to edit each Dockerfile manually.

### ✔️  Fixes
So this could fix the build problems for any environment with a proxy.

If you don't provide the build args you would have to add the `ENV` variables in each Dockerfile. So this should be a much more simpler fix. 

### 📔 Build command example with proxy settings

```bash
docker-compose build \
--build-arg HTTP_PROXY=http://<user>:<password>@<proxy_ip>:3128/ \
--build-arg HTTPS_PROXY=http://<user>:<password>@<proxy_ip>:3128/ \
--build-arg NO_PROXY=localhost,127.0.0.0/8
``` 