### PR TITLE
[MM-18794] mattermost command line broken in Docker since the 5.11.1 -> 5.12.0 transition

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,11 @@ services:
       - MM_USERNAME=mmuser
       - MM_PASSWORD=mmuser_password
       - MM_DBNAME=mattermost
+
+      # use the credentials you've set above, in the format:
+      # MM_SQLSETTINGS_DATASOURCE=postgres://${MM_USERNAME}:${MM_PASSWORD}@db:5432/${MM_DBNAME}?sslmode=disable&connect_timeout=10
+      - MM_SQLSETTINGS_DATASOURCE=postgres://mmuser:mmuser_password@db:5432/mattermost?sslmode=disable&connect_timeout=10
+
       # in case your config is not in default location
       #- MM_CONFIG=/mattermost/config/config.json
 


### PR DESCRIPTION
#### Summary
- The env variable `MM_SQLSETTINGS_DATASOURCE` exported in `app/entrypoint.sh` isn't kept as an environment variable in the app container after startup. 
- One solution is to manually define it in the `docker-compose.yml` file. This keeps it in the environment, so when the CLI is started sometime later, the correct database connection string is used.
- Totally open to other solutions. 
- I tried to reference the variables (eg, `${MM_USERNAME}`) in the string, but docker-compose isn't set up to do that. One way would be to use an environment file, import it, and then you could reference those variables. Do you want to do that @cpanato?

#### Next Steps:
- This is being felt by customers using 5.12-on, should we update those releases with this?

#### Ticket
- [MM-18794](https://mattermost.atlassian.net/browse/MM-18794)