### PR TITLE
Fix for letsencrypt, where to run on 443 you need to setcap cap_net_b…

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -18,6 +18,7 @@ RUN apk add --no-cache \
 	jq \
 	libc6-compat \
 	libffi-dev \
+    libcap \
 	linux-headers \
 	mailcap \
 	netcat-openbsd \
@@ -34,7 +35,8 @@ RUN mkdir -p /mattermost/data /mattermost/plugins /mattermost/client/plugins \
     && rm -rf /mattermost/config/config.json \
     && addgroup -g ${PGID} mattermost \
     && adduser -D -u ${PUID} -G mattermost -h /mattermost -D mattermost \
-    && chown -R mattermost:mattermost /mattermost /config.json.save /mattermost/plugins /mattermost/client/plugins
+    && chown -R mattermost:mattermost /mattermost /config.json.save /mattermost/plugins /mattermost/client/plugins \
+    && setcap cap_net_bind_service=+ep /mattermost/bin/mattermost
 
 USER mattermost
 


### PR DESCRIPTION
Fix for letsencrypt, where to run on 443 you need to setcap cap_net_bind_service=+ep ./bin/mattermost. Note, this is needed internally from the container even if you set the correct CAP_NET_BIND_SERVICE in the docker compose env