### PR TITLE
Fixes for the smooth deployment of Team edition.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,13 @@ The following instructions deploy Mattermost in a production configuration using
 
 If you want to install Enterprise Edition, you can skip this section.
 
-To install the team edition, change `build: app` to `build:` and uncomment out these lines in docker-compose.yaml file:
+To install the team edition, change `build: app` to `build:` and uncomment out these lines in `app:` services block to make it look like below in docker-compose.yaml file:
 ```yaml
-context: app
-args:
-  - edition=team
+app:
+  build:
+    context: app
+    args:
+      - edition=team
 ```
 The `app` Dockerfile will read the `edition` build argument to install Team (`edition = 'team'`) or Enterprise (`edition != team`) edition.
 

--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@ The following instructions deploy Mattermost in a production configuration using
 
 If you want to install Enterprise Edition, you can skip this section.
 
-To install the team edition, uncomment out these lines in docker-compose.yaml file:
+To install the team edition, change `build: app` to `build:` and uncomment out these lines in docker-compose.yaml file:
 ```yaml
+context: app
 args:
   - edition=team
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
 
   app:
     build: app
-      # uncomment following lines for team edition or change UID/GID
+      # change `build:app` to `build:` and uncomment following lines for team edition or change UID/GID
       # context: app
       # args:
       #   - edition=team

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
   app:
     build: app
       # uncomment following lines for team edition or change UID/GID
+      # context: app
       # args:
       #   - edition=team
       #   - PUID=1000


### PR DESCRIPTION


<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

### Summary
**Problem:**
For installation of Team Edition, simply commenting out the two lines mentioned in README does not work. Created issue #437 for it.

**Solution:**
After looking at a few blogs and the commit history of the `docker-compose.yml` . I observed that the `context: ` has been deleted by some other PR which was previously present. So I have 
added it back to make team edition deployments work.

**Fixes:**
	- Added the context block in `docker-compose.yml`
	- Added the subsequent changes in the installation instructions in README.md

#### Ticket Link
Probably wrong docker-compose file syntax #437 


