### PR TITLE
Installing missing package pv

### DIFF
--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -12,6 +12,7 @@ RUN apk add --no-cache \
       python-dev \
       py-pip \
       py-cryptography \
+      pv \
     && pip --no-cache-dir install 'wal-e<1.0.0' envdir \
     && rm -rf /var/cache/apk/* /tmp/* /var/tmp/*
 


### PR DESCRIPTION
I tried to use wal-e as mentioned on dockerhub (see https://hub.docker.com/r/mattermost/mattermost-prod-db). To do the base backup I had to do some additional steps (see https://github.com/mattermost/mattermost-docker/issues/346):
- mount a volume into the database docker container (path in the container is /etc/wal-e.d/env) and put all credentials and the s3 prefix to this folder
- exec into the container and create a superuser (Command: CREATE USER postgres SUPERUSER;)

Now it still fails with the message, that the package *pv* is missing

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

