### PR TITLE
bump to 5.19.0

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.10
 
 # Some ENV variables
 ENV PATH="/mattermost/bin:${PATH}"
-ENV MM_VERSION=5.18.1
+ENV MM_VERSION=5.19.0
 
 # Build argument to set Mattermost edition
 ARG edition=enterprise


### PR DESCRIPTION
#### Summary
Mattermost 5.19 was released today, bumping the Dockerfile ENV variable so Docker installs can upgrade.

#### Ticket Link
N/A