### PR TITLE
add openssl-dev since this is needed to compile py-cryptography

### DIFF
--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -9,6 +9,7 @@ RUN apk add --no-cache \
       libc6-compat \
       libffi-dev \
       linux-headers \
+      openssl-dev \
       python-dev \
       py-pip \
       py-cryptography \


### PR DESCRIPTION
#### Summary
pip install fails lately due to the missing openssl headers which are needed for compiling the native code part of py-cryptography
