### PR TITLE
Removes the deprecated nginx ssl directive (#451)

### DIFF
--- a/web/mattermost-ssl
+++ b/web/mattermost-ssl
@@ -12,7 +12,6 @@ map $http_x_forwarded_proto $proxy_x_forwarded_proto {
 server {
     listen 443 ssl http2;
 
-    ssl on;
     ssl_certificate /cert/cert.pem;
     ssl_certificate_key /cert/key-no-password.pem;
     ssl_session_timeout 5m;


### PR DESCRIPTION
#### Summary

Removes the deprecated nginx directive `ssl` which causes a warning when starting `mattermost-docker`.

A replacement is not necessary, because the `ssl` flag is already set on the `listen` directive here:

https://github.com/mattermost/mattermost-docker/blob/492ecd5ca3c761e309834ba0389dd13e7bc431d4/web/mattermost-ssl#L13

#### Ticket Link
Fixes #451.

