### PR TITLE
web entrypoint: forcefully link existing config

### DIFF
--- a/web/entrypoint.sh
+++ b/web/entrypoint.sh
@@ -12,7 +12,7 @@ else
   echo "linking plain config"
 fi
 # Linking Nginx configuration file
-ln -s /etc/nginx/sites-available/mattermost$ssl /etc/nginx/conf.d/mattermost.conf
+ln -s -f /etc/nginx/sites-available/mattermost$ssl /etc/nginx/conf.d/mattermost.conf
 
 # Setup app host and port on configuration file
 sed -i "s/{%APP_HOST%}/${APP_HOST}/g" /etc/nginx/conf.d/mattermost.conf


### PR DESCRIPTION
When trying to enable SSL, I added the certificate as described here: https://github.com/mattermost/mattermost-docker#install-with-ssl-certificate

However, the web server was still listenting to port 80 instead of port 443 and it took me a moment to see why. The startup output of docker-compose contains this:
```
web_1  | ln: /etc/nginx/conf.d/mattermost.conf: File exists
web_1  | found certificate and key, linking ssl config
```

While the second line suggests, that the config *mattermost-ssl* is being used, the first line tells us, that the linking was not successful, because the symlink already exists from a previous execution. The existing link can be overwritten by adding `-f --force` to `ln`.

Related: mattermost#366 (mattermost#366 would probably need to be updated with the same change)

