### PR TITLE
Remove unused ENV variable from docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,6 +59,3 @@ services:
       # This directory must have cert files if you want to enable SSL
       - ./volumes/web/cert:/cert:ro
       - /etc/localtime:/etc/localtime:ro
-    # Uncomment for SSL
-    # environment:
-    #  - MATTERMOST_ENABLE_SSL=true


### PR DESCRIPTION
I could not find any use of `MATTERMOST_ENABLE_SSL`. It's therefore only confusing to have it in the docker-compose as an apparent configuration flag.

This PR is obsolete should https://github.com/mattermost/mattermost-docker/pull/366 be accepted.