### PR TITLE
Fix the linking of the nginx configuration file

### DIFF
--- a/web/entrypoint.sh
+++ b/web/entrypoint.sh
@@ -11,6 +11,8 @@ if [ -f "/cert/cert.pem" -a -f "/cert/key-no-password.pem" ]; then
 else
   echo "linking plain config"
 fi
+# Ensure that the configuration file is not present before linking. 
+test -w /etc/nginx/conf.d/mattermost.conf && rm /etc/nginx/conf.d/mattermost.conf
 # Linking Nginx configuration file
 ln -s -f /etc/nginx/sites-available/mattermost$ssl /etc/nginx/conf.d/mattermost.conf
 


### PR DESCRIPTION
In this commit I'm adding some logic to ensure that the `entrypoint.sh`
file handles a pre-existing `mattermost.conf` file within the nginx
folder.

During deployment of some more custom nginx configuration it was
noticed that the linking process fails, because a file already exists
with the filesystem.

Signed-off-by: Akendo <akendo@akendo.eu>

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

