### PR TITLE
[GH-469] Fixing docker-compose build process

### DIFF
--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -15,6 +15,7 @@ RUN apk add --no-cache \
       py-cryptography \
       pv \
       libressl-dev \
+    && pip install --upgrade pip \
     && pip --no-cache-dir install -c pip-constraints.txt 'wal-e<1.0.0' envdir \
     && rm -rf /var/cache/apk/* /tmp/* /var/tmp/*
 


### PR DESCRIPTION




<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Currently the command `docker-compose build` throws an error for building the database because it uses an old pip version.

This PR updates pip right before it is called. Anyways this should just be a temporary fix because the image uses Python 2.7 wich out of support since Jan 2020

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

Fixes: https://github.com/mattermost/mattermost-docker/issues/469