### PR TITLE
Add ?src=docker-app query parameter to identify download source

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -29,8 +29,8 @@ RUN apk add --no-cache \
 # Get Mattermost
 RUN mkdir -p /mattermost/data /mattermost/plugins /mattermost/client/plugins \
     && if [ ! -z "$MM_BINARY" ]; then curl $MM_BINARY | tar -xvz ; \
-      elif [ "$edition" = "team" ] ; then curl https://releases.mattermost.com/$MM_VERSION/mattermost-team-$MM_VERSION-linux-amd64.tar.gz | tar -xvz ; \
-      else curl https://releases.mattermost.com/$MM_VERSION/mattermost-$MM_VERSION-linux-amd64.tar.gz | tar -xvz ; fi \
+      elif [ "$edition" = "team" ] ; then curl https://releases.mattermost.com/$MM_VERSION/mattermost-team-$MM_VERSION-linux-amd64.tar.gz?src=docker-app | tar -xvz ; \
+      else curl https://releases.mattermost.com/$MM_VERSION/mattermost-$MM_VERSION-linux-amd64.tar.gz?src=docker-app | tar -xvz ; fi \
     && cp /mattermost/config/config.json /config.json.save \
     && rm -rf /mattermost/config/config.json \
     && addgroup -g ${PGID} mattermost \


### PR DESCRIPTION
#### Context:

Right now, multiple sources point to the server binaries on releases.mattermost.com, including the download page, upgrade instructions, Helm charts, version archive, and others.

We can identify the download source by adding a querystring to the url, i.e. https://releases.mattermost.com/5.22.1/mattermost-5.22.1-linux-amd64.tar.gz?src=docker-app

The intent is that we can then identify sources of downloads, identify those that typically lead to an unsuccessful server activation, and improve the experience for the developer/administrator.

This PR adds the "?src=docker-app" querysting tag to download source for the Docker app, so we know when someone downloaded it from this source

See https://github.com/mattermost/docs/pull/3596 for a similar change made to download sources on the version archive page.

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

