### PR TITLE
Remove sudo: required as it is deprecated.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-sudo: required
-
 services:
     - docker
 


### PR DESCRIPTION
#### Summary

Remove 'sudo: required' as it is now  deprecated per the documentation:

https://changelog.travis-ci.com/the-container-based-build-environment-is-fully-deprecated-84517

#### Ticket Link
  Fixes https://github.com/mattermost/mattermost-docker/issues/470


