### PR TITLE
DOPS-215: Add MM_INSTALL_TYPE=docker environment variable.

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -3,6 +3,7 @@ FROM alpine:3.10
 # Some ENV variables
 ENV PATH="/mattermost/bin:${PATH}"
 ENV MM_VERSION=5.27.0
+ENV MM_INSTALL_TYPE=docker
 
 # Build argument to set Mattermost edition
 ARG edition=enterprise


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->Sets an environment variable to get an idea of the preferred installation type.  

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/DOPS-215
