### PR TITLE
Update SSL ciphers and TLS versions in nginx config file

### DIFF
--- a/web/mattermost-ssl
+++ b/web/mattermost-ssl
@@ -1,7 +1,7 @@
 server {
-	listen 80 default_server;
-	server_name _;
-	return 301 https://$host$request_uri;
+    listen 80 default_server;
+    server_name _;
+    return 301 https://$host$request_uri;
 }
 
 map $http_x_forwarded_proto $proxy_x_forwarded_proto {
@@ -15,9 +15,11 @@ server {
     ssl_certificate /cert/cert.pem;
     ssl_certificate_key /cert/key-no-password.pem;
     ssl_session_timeout 5m;
-    ssl_protocols TLSv1 TLSv1.1 TLSv1.2 TLSv1.3;
-    ssl_ciphers HIGH:MEDIUM:!SSLv2:!PSK:!SRP:!ADH:!AECDH;
-    ssl_prefer_server_ciphers on;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    # Please update the ciphers in this file every 6 months.
+    # https://ssl-config.mozilla.org/
+    ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
+    ssl_prefer_server_ciphers off;
 
     location ~ /api/v[0-9]+/(users/)?websocket$ {
         proxy_set_header Upgrade $http_upgrade;
@@ -33,7 +35,7 @@ server {
         proxy_buffers 256 16k;
         proxy_buffer_size 16k;
         proxy_read_timeout 600s;
-	proxy_pass http://{%APP_HOST%}:{%APP_PORT%};
+        proxy_pass http://{%APP_HOST%}:{%APP_PORT%};
     }
 
     location / {
@@ -50,7 +52,7 @@ server {
         proxy_buffers 256 16k;
         proxy_buffer_size 16k;
         proxy_read_timeout 600s;
-	proxy_pass http://{%APP_HOST%}:{%APP_PORT%};
+        proxy_pass http://{%APP_HOST%}:{%APP_PORT%};
     }
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This PR updates the supported ciphers and TLS versions in the nginx SSL config. TLS versions 1.0 and 1.1 are no longer supported by any browser and are considered deprecated. Comparing [client software versions](https://docs.mattermost.com/install/requirements.html#client-software) with [this table of which browsers support TLS 1.2](https://caniuse.com/tls1-2), all Mattermost supported browsers also support TLS 1.2, so we can safely remove TLS 1.0 and 1.1 without impacting many users. The biggest group of affected users would be IE10 users, but IE10 was end of life in January so those users should have moved on by now. Not sure which version of chrome is shipped with the mattermost client, but I am assuming it's not from 2013 so it should support TLS1.2 as well.

With TLS 1.0 and 1.1 support:
https://www.ssllabs.com/ssltest/analyze.html?d=mattermost.copperleaf.cloud

With the changes merged in and no TLS 1.0 and 1.1 support:
https://www.ssllabs.com/ssltest/analyze.html?d=test.mattermost.copperleaf.cloud

