### PR TITLE
Fix permission error in Elastic Beanstalk when writing to config.json…

### DIFF
--- a/contrib/aws/README.md
+++ b/contrib/aws/README.md
@@ -13,3 +13,6 @@ eb init
 eb create prod
 eb open prod
 ```
+
+### Note
+You must chmod the config.json file, then compress the whole folder starting form mattemost-docker/contrib/aws/* and then upload the .zip file to elastic beanstalk. 


### PR DESCRIPTION
#### Summary
It took me a while to figure out that I needed to change the permissions locally of the config.json file for Elastic Beanstalk later to not have any issue reading and writing to the file. The change is preserved when compressing the file. 