### PR TITLE
use postgres 10

### DIFF
--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:9.4-alpine
+FROM postgres:10.16-alpine
 
 ENV DEFAULT_TIMEZONE UTC
 
@@ -10,7 +10,7 @@ RUN apk add --no-cache \
       libc6-compat \
       libffi-dev \
       linux-headers \
-      python-dev \
+      python3-dev \
       py-pip \
       py-cryptography \
       pv \


### PR DESCRIPTION
#### Summary
<!--
Mattermost v5.32  requires Postgres 10, drops support for Postgres 9.
Change to Dockerfile builds matter-db from postgres 10.16-alpine image
-->