### PR TITLE
Hardening: Change nginx container to unprivileged

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,11 +54,13 @@ services:
   web:
     build: web
     ports:
-      - "80:80"
-      - "443:443"
+      - "80:8080"
+      - "443:8443"
     read_only: true
     restart: unless-stopped
     volumes:
       # This directory must have cert files if you want to enable SSL
       - ./volumes/web/cert:/cert:ro
       - /etc/localtime:/etc/localtime:ro
+    cap_drop:
+      - ALL

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,17 +1,38 @@
-FROM nginx:mainline-alpine
+FROM nginxinc/nginx-unprivileged:mainline-alpine
+
+USER root
 
 # Remove default configuration and add our custom Nginx configuration files
 RUN rm /etc/nginx/conf.d/default.conf \
     && apk add --no-cache curl
 
 COPY ["./mattermost", "./mattermost-ssl", "/etc/nginx/sites-available/"]
-COPY ./security.conf /etc/nginx/conf.d/
 
 # Add and setup entrypoint
 COPY entrypoint.sh /
 
+RUN chown -R nginx:nginx /etc/nginx/sites-available && \
+         chown -R nginx:nginx /var/cache/nginx && \
+         chown -R nginx:nginx /var/log/nginx && \
+         chown -R nginx:nginx /etc/nginx/conf.d && \
+         chown nginx:nginx entrypoint.sh
+RUN touch /var/run/nginx.pid && \
+         chown -R nginx:nginx /var/run/nginx.pid
+
+COPY ./security.conf /etc/nginx/conf.d/
+
+RUN chown -R nginx:nginx /etc/nginx/conf.d/security.conf
+
+RUN chmod u+x /entrypoint.sh
+
+RUN sed -i "/^http {/a \    proxy_buffering off;\n" /etc/nginx/nginx.conf
+RUN sed -i '/temp_path/d' /etc/nginx/nginx.conf \
+    && sed -i 's!/tmp/nginx.pid!/var/run/nginx.pid!g' /etc/nginx/nginx.conf
+
+USER nginx
+
 #Healthcheck to make sure container is ready
-HEALTHCHECK CMD curl --fail http://localhost:80 || exit 1
+HEALTHCHECK CMD curl --fail http://localhost:8080 || exit 1
 
 ENTRYPOINT ["/entrypoint.sh"]
 

--- a/web/mattermost
+++ b/web/mattermost
@@ -4,7 +4,7 @@ map $http_x_forwarded_proto $proxy_x_forwarded_proto {
 }
 
 server {
-    listen 80;
+    listen 8080;
 
     location ~ /api/v[0-9]+/(users/)?websocket$ {
         proxy_set_header Upgrade $http_upgrade;

--- a/web/mattermost-ssl
+++ b/web/mattermost-ssl
@@ -1,5 +1,5 @@
 server {
-    listen 80 default_server;
+    listen 8080 default_server;
     server_name _;
     return 301 https://$host$request_uri;
 }
@@ -10,7 +10,7 @@ map $http_x_forwarded_proto $proxy_x_forwarded_proto {
 }
 
 server {
-    listen 443 ssl http2;
+    listen 8443 ssl http2;
 
     ssl_certificate /cert/cert.pem;
     ssl_certificate_key /cert/key-no-password.pem;


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary

**Hardening for production environments.**
According to ['OWASP Docker Security Cheat Sheet'](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html) Docker container should be configured with unprivileged user. In addition nginx container is hardened by dropping all capabilities. `The most secure setup is to drop all capabilities --cap-drop all`

Changes:
- Official nginxinc unprivileged container `nginx:mainline-alpine` -> `nginxinc/nginx-unprivileged:mainline-alpine` 
- Required changes from [nginxinc/nginx-unprivileged](https://github.com/nginxinc/docker-nginx-unprivileged)

> *   The default NGINX listen port is now `8080` instead of `80`.
> *   The default NGINX user directive in `/etc/nginx/nginx.conf` has been removed.
> *   The default NGINX PID has been moved from `/var/run/nginx.pid` to `/tmp/nginx.pid`.
> *   Change `*_temp_path` variables to `/tmp/*`.
- Nginx container is run with limited set of Linux kernel capabilities `cap_drop: - ALL`