### PR TITLE
[GH-401] Add support for SELinux enabled Operating Systems

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     read_only: true
     restart: unless-stopped
     volumes:
-      - ./volumes/db/var/lib/postgresql/data:/var/lib/postgresql/data
+      - ./volumes/db/var/lib/postgresql/data:/var/lib/postgresql/data:Z
       - /etc/localtime:/etc/localtime:ro
     environment:
       - POSTGRES_USER=mmuser
@@ -29,11 +29,11 @@ services:
       #   - PGID=1000
     restart: unless-stopped
     volumes:
-      - ./volumes/app/mattermost/config:/mattermost/config:rw
-      - ./volumes/app/mattermost/data:/mattermost/data:rw
-      - ./volumes/app/mattermost/logs:/mattermost/logs:rw
-      - ./volumes/app/mattermost/plugins:/mattermost/plugins:rw
-      - ./volumes/app/mattermost/client-plugins:/mattermost/client/plugins:rw
+      - ./volumes/app/mattermost/config:/mattermost/config:rw,Z
+      - ./volumes/app/mattermost/data:/mattermost/data:rw,Z
+      - ./volumes/app/mattermost/logs:/mattermost/logs:rw,Z
+      - ./volumes/app/mattermost/plugins:/mattermost/plugins:rw,Z
+      - ./volumes/app/mattermost/client-plugins:/mattermost/client/plugins:rw,Z
       - /etc/localtime:/etc/localtime:ro
       # When you want to use SSO with GitLab, you have to add the cert pki chain of GitLab inside Alpine
       # to avoid Token request failed: certificate signed by unknown authority (link: https://github.com/mattermost/mattermost-server/issues/13059)
@@ -60,5 +60,5 @@ services:
     restart: unless-stopped
     volumes:
       # This directory must have cert files if you want to enable SSL
-      - ./volumes/web/cert:/cert:ro
+      - ./volumes/web/cert:/cert:ro,Z
       - /etc/localtime:/etc/localtime:ro


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This PR adds support for volume binding on SELinux enabled hosts. 
[Docker docs:](https://docs.docker.com/storage/bind-mounts/)
> The Z option indicates that the bind mount content is private and unshared.

Systems where SELinux is not installed `Z` option doesn't affect docker-compose installation process.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

https://github.com/mattermost/mattermost-docker/issues/401
https://github.com/mattermost/mattermost-docker/issues/24
https://github.com/mattermost/mattermost-docker/issues/262