### PR TITLE
Upgrade Postgres to 10 for 5.33.0

### DIFF
--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -1,6 +1,8 @@
-FROM postgres:9.4-alpine
+FROM postgres:10-alpine
 
 ENV DEFAULT_TIMEZONE UTC
+# Mandatory nowdays with PG 10
+ENV WAL_LEVEL logical
 
 # Install some packages to use WAL
 RUN echo "azure<5.0.0" > pip-constraints.txt
@@ -10,8 +12,8 @@ RUN apk add --no-cache \
       libc6-compat \
       libffi-dev \
       linux-headers \
-      python-dev \
-      py-pip \
+      python3-dev \
+      py3-pip \
       py-cryptography \
       pv \
       libressl-dev \


### PR DESCRIPTION
- upgrade python-dev to python3-dev since python2 is no longer available
- py-pi to pi3-pip

fixes #528 #489 

For anybody in need and avoiding the complexity, you can use the DB images from
https://hub.docker.com/repository/docker/eugenmayer/mattermost-db
build by https://github.com/EugenMayer/mattermost-boilerplate - you will find versions prior 5.33.0 based on pg 9.6 and versions above base on pg 10. 

Those images are unmodified variants of this repo - just publish to docker-hub for obvious convenience reasons i guess :)