### PR TITLE
Support in-database configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ PostgreSQL allows two other variables `sslrootcert` and `sslcrl` for connection 
 If you use a Mattermost configuration file on a different location than the default one (`/mattermost/config/config.json`) :
 * `MM_CONFIG`: configuration file location inside the container.
 
+You can use [in-database configuration](https://docs.mattermost.com/administration/config-in-database.html) by defining:
+* `CONFIG_USE_DB`: `true` to read and store configuration within the database
+
 If you choose to use MySQL instead of PostgreSQL, you should set a different datasource and SQL driver :
 * `DB_PORT_NUMBER` : `3306`
 * `MM_SQLSETTINGS_DRIVERNAME` : `mysql`


### PR DESCRIPTION
#### Summary
Adds a flag to support in-database configuration through the `CONFIG_USE_DB` environment variable. If this is `true`, the configuration file will not be created if it does not exist. It supports using the custom `MM_SQLSETTINGS_DATASOURCE` if that exists.

On new deployments with `CONFIG_USE_DB` enabled, none of the defaults written into the configuration file are created. Further, it assumes existing installations migrate their configuration over before enabling `CONFIG_USE_DB` as described in the [documentation](https://docs.mattermost.com/administration/config-in-database.html)
